### PR TITLE
[ENG] Fix Security workflow Scorecard permissions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -10,7 +10,6 @@ on:
 permissions:
   actions: read
   contents: read
-  security-events: write
 
 concurrency:
   group: security-${{ github.ref }}
@@ -20,6 +19,9 @@ jobs:
   semgrep:
     name: Semgrep CE
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v3
@@ -38,7 +40,7 @@ jobs:
             --output semgrep.sarif \
             spindlex
       - name: Upload Semgrep SARIF
-        if: always()
+        if: always() && hashFiles('semgrep.sarif') != ''
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: semgrep.sarif
@@ -72,6 +74,9 @@ jobs:
   gitleaks:
     name: Gitleaks
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@v4
       - name: Run Gitleaks
@@ -88,7 +93,7 @@ jobs:
               --report-path /repo/gitleaks.sarif \
               --exit-code 1
       - name: Upload Gitleaks SARIF
-        if: always()
+        if: always() && hashFiles('gitleaks.sarif') != ''
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: gitleaks.sarif
@@ -96,6 +101,9 @@ jobs:
   trivy:
     name: Trivy Filesystem
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@v4
       - name: Run Trivy filesystem scan
@@ -110,15 +118,17 @@ jobs:
           output: trivy-results.sarif
           exit-code: "1"
       - name: Upload Trivy SARIF
-        if: always()
+        if: always() && hashFiles('trivy-results.sarif') != ''
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: trivy-results.sarif
 
   scorecard:
     name: OpenSSF Scorecard
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
       security-events: write
       id-token: write
@@ -133,7 +143,7 @@ jobs:
           results_format: sarif
           publish_results: true
       - name: Upload Scorecard SARIF
-        if: always()
+        if: always() && hashFiles('scorecard.sarif') != ''
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: scorecard.sarif


### PR DESCRIPTION
## Description

Fixes the failing `Security` workflow on `main`.

Root cause from the failed `OpenSSF Scorecard` job:

- Scorecard publishing rejects workflows with workflow-level write permissions.
- The workflow had `security-events: write` at the top level.
- Scorecard failed with: `workflow verification failed: global perm is set to write`.

This change keeps workflow-level permissions read-only and moves `security-events: write` to only the jobs that upload SARIF.

## Type of Change

- [ ] bug - Bug fix; creates a patch release.
- [ ] feature - New feature; creates a minor release.
- [ ] breaking - Breaking change; creates a major release.
- [ ] docs - Documentation-only change; no release.
- [x] refactor - Non-functional cleanup or refactor; no release.
- [ ] test - Test-only change; no release.

## How Has This Been Tested?

- [x] Manual Test: `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/security.yml')"`
- [x] Manual Test: `git diff --check`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings