### PR TITLE
[codex] ci: require changelog updates for release PRs

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -66,6 +66,20 @@ jobs:
       - run: uv pip install --system -e ".[test]"
       - run: pytest tests -m "not integration and not real_server and not slow and not performance"
 
+  changelog-check:
+    name: changelog-check
+    needs: pr-validate
+    if: needs.pr-validate.outputs.release_needed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.11"
+      - run: python scripts/check_changelog_updated.py --event-path "$GITHUB_EVENT_PATH"
+
   docs-build:
     name: docs-build
     runs-on: ubuntu-latest
@@ -125,6 +139,7 @@ jobs:
       - ruff
       - mypy
       - unit-tests
+      - changelog-check
       - docs-build
       - security-fast
       - workflow-lint
@@ -137,6 +152,7 @@ jobs:
           if [ "${{ needs.ruff.result }}" != "success" ]; then exit 1; fi
           if [ "${{ needs.mypy.result }}" != "success" ]; then exit 1; fi
           if [ "${{ needs.unit-tests.result }}" != "success" ]; then exit 1; fi
+          if [ "${{ needs.changelog-check.result }}" != "success" ] && [ "${{ needs.changelog-check.result }}" != "skipped" ]; then exit 1; fi
           if [ "${{ needs.docs-build.result }}" != "success" ]; then exit 1; fi
           if [ "${{ needs.security-fast.result }}" != "success" ]; then exit 1; fi
           if [ "${{ needs.workflow-lint.result }}" != "success" ]; then exit 1; fi

--- a/scripts/check_changelog_updated.py
+++ b/scripts/check_changelog_updated.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Require release-producing pull requests to update the changelog."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+DEFAULT_CHANGELOG = Path("docs/changelog.md")
+
+
+def _event_payload(event_path: Path) -> dict[str, object]:
+    return json.loads(event_path.read_text(encoding="utf-8"))
+
+
+def _pull_request_shas(event_path: Path) -> tuple[str, str]:
+    payload = _event_payload(event_path)
+    pull_request = payload.get("pull_request")
+    if not isinstance(pull_request, dict):
+        raise ValueError("GitHub event payload does not contain a pull_request object.")
+
+    base = pull_request.get("base")
+    head = pull_request.get("head")
+    if not isinstance(base, dict) or not isinstance(head, dict):
+        raise ValueError("GitHub event payload does not contain base/head refs.")
+
+    base_sha = base.get("sha")
+    head_sha = head.get("sha")
+    if not isinstance(base_sha, str) or not isinstance(head_sha, str):
+        raise ValueError("GitHub event payload does not contain base/head SHAs.")
+
+    return base_sha, head_sha
+
+
+def _git_diff(changelog: Path, base_sha: str, head_sha: str) -> str:
+    git = shutil.which("git")
+    if git is None:
+        raise RuntimeError("git executable was not found.")
+
+    result = subprocess.run(  # noqa: S603 - fixed command with GitHub-provided SHAs.
+        [
+            git,
+            "diff",
+            "--unified=0",
+            f"{base_sha}...{head_sha}",
+            "--",
+            changelog.as_posix(),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def _has_added_changelog_content(diff: str) -> bool:
+    for line in diff.splitlines():
+        if not line.startswith("+") or line.startswith("+++"):
+            continue
+        if line[1:].strip():
+            return True
+    return False
+
+
+def changelog_updated(changelog: Path, base_sha: str, head_sha: str) -> bool:
+    diff = _git_diff(changelog, base_sha, head_sha)
+    return _has_added_changelog_content(diff)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--event-path", type=Path, required=True)
+    parser.add_argument("--changelog", type=Path, default=DEFAULT_CHANGELOG)
+    args = parser.parse_args(argv)
+
+    try:
+        base_sha, head_sha = _pull_request_shas(args.event_path)
+        updated = changelog_updated(args.changelog, base_sha, head_sha)
+    except Exception as exc:
+        print(f"Changelog check failed: {exc}", file=sys.stderr)
+        return 1
+
+    if updated:
+        print(f"{args.changelog.as_posix()} has release-note changes.")
+        return 0
+
+    print(
+        f"{args.changelog.as_posix()} must be updated for bug, feature, "
+        "and breaking-change PRs.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_check_changelog_updated.py
+++ b/tests/scripts/test_check_changelog_updated.py
@@ -1,0 +1,48 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2] / "scripts" / "check_changelog_updated.py"
+)
+SPEC = importlib.util.spec_from_file_location("check_changelog_updated", SCRIPT_PATH)
+assert SPEC is not None
+check_changelog_updated = importlib.util.module_from_spec(SPEC)
+sys.modules["check_changelog_updated"] = check_changelog_updated
+assert SPEC.loader is not None
+SPEC.loader.exec_module(check_changelog_updated)
+
+
+def test_detects_added_changelog_content():
+    diff = """diff --git a/docs/changelog.md b/docs/changelog.md
+index 1111111..2222222 100644
+--- a/docs/changelog.md
++++ b/docs/changelog.md
+@@ -5,0 +6,2 @@
++### Fixed
++* Fixed release planning.
+"""
+
+    assert check_changelog_updated._has_added_changelog_content(diff)
+
+
+def test_ignores_empty_added_lines():
+    diff = """diff --git a/docs/changelog.md b/docs/changelog.md
+index 1111111..2222222 100644
+--- a/docs/changelog.md
++++ b/docs/changelog.md
+@@ -5,0 +6,1 @@
++
+"""
+
+    assert not check_changelog_updated._has_added_changelog_content(diff)
+
+
+def test_ignores_file_header_only():
+    diff = """diff --git a/docs/changelog.md b/docs/changelog.md
+index 1111111..2222222 100644
+--- a/docs/changelog.md
++++ b/docs/changelog.md
+"""
+
+    assert not check_changelog_updated._has_added_changelog_content(diff)


### PR DESCRIPTION
## Description

Adds a PR-gate check that runs only for release-producing PR types and requires `docs/changelog.md` to receive non-empty added content before merge.

This keeps release notes current for `bug`, `feature`, and `breaking` PRs while skipping non-release changes such as docs, refactors, tests, and CI-only maintenance.

Fixes # (issue)

## Type of Change

Select exactly one option. These stable tokens are parsed by CI and release automation.

- [ ] bug - Bug fix; creates a patch release.
- [ ] feature - New feature; creates a minor release.
- [ ] breaking - Breaking change; creates a major release.
- [ ] docs - Documentation-only change; no release.
- [x] refactor - Non-functional cleanup or refactor; no release.
- [ ] test - Test-only change; no release.

## How Has This Been Tested?

- [x] **Unit Tests**: `.venv/bin/python -m pytest tests/scripts/test_validate_pr_body.py tests/scripts/test_check_changelog_updated.py`
- [ ] **Integration Tests**: `pytest -m integration`
- [x] **Manual Test**: ran Ruff check/format on the new changelog helper and verified `git diff --check`.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
