### PR TITLE
[ENG] Add failure tracking automation

### DIFF
--- a/.github/ISSUE_TEMPLATE/ci_failure.yml
+++ b/.github/ISSUE_TEMPLATE/ci_failure.yml
@@ -1,0 +1,71 @@
+name: CI Failure
+description: Track a post-merge CI failure that needs maintainer triage.
+title: "[CI] "
+labels: ["ci", "triage"]
+body:
+  - type: input
+    id: workflow
+    attributes:
+      label: Workflow name
+    validations:
+      required: true
+  - type: input
+    id: job
+    attributes:
+      label: Job name
+    validations:
+      required: true
+  - type: input
+    id: run_url
+    attributes:
+      label: Run URL
+    validations:
+      required: true
+  - type: input
+    id: sha
+    attributes:
+      label: Commit SHA
+    validations:
+      required: true
+  - type: input
+    id: branch
+    attributes:
+      label: Branch
+    validations:
+      required: true
+  - type: dropdown
+    id: failure_class
+    attributes:
+      label: Failure class
+      options:
+        - pr-failure
+        - infra-flake
+        - ci-flake
+        - release-blocked
+        - security-blocker
+        - publish-partial
+        - code-regression
+    validations:
+      required: true
+  - type: textarea
+    id: summary
+    attributes:
+      label: Failure summary
+    validations:
+      required: true
+  - type: input
+    id: first_seen
+    attributes:
+      label: First seen
+  - type: input
+    id: latest_seen
+    attributes:
+      label: Latest seen
+  - type: input
+    id: rerun_result
+    attributes:
+      label: Rerun result
+  - type: input
+    id: owner
+    attributes:
+      label: Suspected owner

--- a/.github/ISSUE_TEMPLATE/flaky_pipeline.yml
+++ b/.github/ISSUE_TEMPLATE/flaky_pipeline.yml
@@ -1,0 +1,58 @@
+name: Flaky Pipeline
+description: Track a repeated CI flake until the stability threshold is met.
+title: "[Flake] "
+labels: ["flake", "ci", "triage"]
+body:
+  - type: input
+    id: workflow
+    attributes:
+      label: Workflow
+    validations:
+      required: true
+  - type: input
+    id: job
+    attributes:
+      label: Job
+    validations:
+      required: true
+  - type: input
+    id: runner
+    attributes:
+      label: Runner
+  - type: input
+    id: python_version
+    attributes:
+      label: Python version
+  - type: textarea
+    id: signature
+    attributes:
+      label: Failure signature
+    validations:
+      required: true
+  - type: input
+    id: frequency
+    attributes:
+      label: Frequency
+    validations:
+      required: true
+  - type: input
+    id: first_seen
+    attributes:
+      label: First seen
+  - type: input
+    id: last_seen
+    attributes:
+      label: Last seen
+  - type: input
+    id: last_successful_run
+    attributes:
+      label: Last successful run
+  - type: input
+    id: suspected_cause
+    attributes:
+      label: Suspected cause
+  - type: textarea
+    id: close_condition
+    attributes:
+      label: Close condition
+      value: Close after 3 consecutive scheduled/main runs pass.

--- a/.github/ISSUE_TEMPLATE/release_blocked.yml
+++ b/.github/ISSUE_TEMPLATE/release_blocked.yml
@@ -1,0 +1,53 @@
+name: Release Blocked
+description: Track a release gate failure or partial publish state.
+title: "[Release] "
+labels: ["release-blocked", "ci", "triage"]
+body:
+  - type: input
+    id: source_pr
+    attributes:
+      label: Source PR
+  - type: input
+    id: source_sha
+    attributes:
+      label: Source SHA
+    validations:
+      required: true
+  - type: input
+    id: release_type
+    attributes:
+      label: Release type
+    validations:
+      required: true
+  - type: input
+    id: planned_version
+    attributes:
+      label: Planned version
+    validations:
+      required: true
+  - type: input
+    id: failed_stage
+    attributes:
+      label: Failed stage
+    validations:
+      required: true
+  - type: input
+    id: run_url
+    attributes:
+      label: Run URL
+    validations:
+      required: true
+  - type: input
+    id: artifact_state
+    attributes:
+      label: Artifact state
+  - type: input
+    id: pypi_state
+    attributes:
+      label: PyPI state
+  - type: textarea
+    id: required_action
+    attributes:
+      label: Required action
+    validations:
+      required: true

--- a/.github/workflows/ci-matrix.yml
+++ b/.github/workflows/ci-matrix.yml
@@ -8,6 +8,7 @@ on:
       - "spindlex/**"
       - "tests/**"
       - "scripts/**"
+      - ".github/ISSUE_TEMPLATE/**"
       - "pyproject.toml"
       - ".github/workflows/ci-matrix.yml"
       - ".github/workflows/integration.yml"
@@ -26,6 +27,12 @@ on:
     - cron: "23 3 * * 1"
   workflow_dispatch:
   workflow_call:
+    inputs:
+      track_failures:
+        description: "Track standalone matrix failures with deduplicated issues."
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -65,3 +72,38 @@ jobs:
           files: ./coverage.xml
           flags: unit
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  failure-tracking:
+    name: Matrix failure tracking
+    needs: unit-matrix
+    if: >
+      always() &&
+      github.event_name != 'pull_request' &&
+      (github.event_name != 'workflow_call' || inputs.track_failures) &&
+      needs.unit-matrix.result == 'failure'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.11"
+      - name: Track repeated compatibility failures
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          python scripts/track_workflow_failure.py ci \
+            --repository "${{ github.repository }}" \
+            --token "$GITHUB_TOKEN" \
+            --workflow-name "${{ github.workflow }}" \
+            --workflow-file "ci-matrix.yml" \
+            --run-id "${{ github.run_id }}" \
+            --run-url "$RUN_URL" \
+            --branch "${{ github.ref_name }}" \
+            --source-sha "${{ github.sha }}" \
+            --event-name "${{ github.event_name }}" \
+            --failed-stage "unit-matrix"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,3 +106,36 @@ jobs:
           if [ "${{ needs.unit-tests.result }}" != "success" ]; then exit 1; fi
           if [ "${{ needs.docs-build.result }}" != "success" ]; then exit 1; fi
           echo "All checks passed!"
+
+  failure-tracking:
+    name: Pipeline failure tracking
+    needs: check
+    if: >
+      always() &&
+      needs.check.result == 'failure'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.11"
+      - name: Track post-merge pipeline failure
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          python scripts/track_workflow_failure.py ci \
+            --repository "${{ github.repository }}" \
+            --token "$GITHUB_TOKEN" \
+            --workflow-name "${{ github.workflow }}" \
+            --workflow-file "ci.yml" \
+            --run-id "${{ github.run_id }}" \
+            --run-url "$RUN_URL" \
+            --branch "${{ github.ref_name }}" \
+            --source-sha "${{ github.sha }}" \
+            --event-name "${{ github.event_name }}" \
+            --failed-stage "quality-gate"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,6 +8,7 @@ on:
       - "spindlex/**"
       - "tests/**"
       - "scripts/**"
+      - ".github/ISSUE_TEMPLATE/**"
       - "pyproject.toml"
       - ".github/workflows/ci-matrix.yml"
       - ".github/workflows/integration.yml"
@@ -26,6 +27,12 @@ on:
     - cron: "47 3 * * *"
   workflow_dispatch:
   workflow_call:
+    inputs:
+      track_failures:
+        description: "Track standalone integration failures with deduplicated issues."
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -62,3 +69,38 @@ jobs:
           files: ./coverage.xml
           flags: integration
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  failure-tracking:
+    name: Integration failure tracking
+    needs: docker-protocol
+    if: >
+      always() &&
+      github.event_name != 'pull_request' &&
+      (github.event_name != 'workflow_call' || inputs.track_failures) &&
+      needs.docker-protocol.result == 'failure'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.11"
+      - name: Track repeated integration failures
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          python scripts/track_workflow_failure.py ci \
+            --repository "${{ github.repository }}" \
+            --token "$GITHUB_TOKEN" \
+            --workflow-name "${{ github.workflow }}" \
+            --workflow-file "integration.yml" \
+            --run-id "${{ github.run_id }}" \
+            --run-url "$RUN_URL" \
+            --branch "${{ github.ref_name }}" \
+            --source-sha "${{ github.sha }}" \
+            --event-name "${{ github.event_name }}" \
+            --failed-stage "docker-protocol"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,10 @@ on:
       - ".github/workflows/release.yml"
       - ".github/workflows/ci-matrix.yml"
       - ".github/workflows/integration.yml"
+      - ".github/ISSUE_TEMPLATE/**"
       - "scripts/plan_release.py"
       - "scripts/sync_project_version.py"
+      - "scripts/track_workflow_failure.py"
       - "scripts/validate_pr_body.py"
       - "tests/scripts/**"
       - "pyproject.toml"
@@ -154,6 +156,8 @@ jobs:
       needs.compatibility-matrix.result == 'success' &&
       needs.integration.result == 'success'
     runs-on: ubuntu-latest
+    outputs:
+      release_complete: ${{ steps.release.outputs.release_complete }}
     permissions:
       contents: write
       id-token: write
@@ -252,7 +256,8 @@ jobs:
             sleep 30
           done
           exit 1
-      - name: Push release commit, tag, and GitHub Release
+      - id: release
+        name: Push release commit, tag, and GitHub Release
         if: steps.prepare.outputs.publish_needed == 'true'
         env:
           GH_TOKEN: ${{ steps.release-token.outputs.token }}
@@ -274,3 +279,48 @@ jobs:
           gh release create "$TAG" \
             --title "$TAG" \
             --notes-file release-notes.md
+
+          echo "release_complete=true" >> "$GITHUB_OUTPUT"
+
+  failure-tracking:
+    name: Release failure tracking
+    needs:
+      - plan
+      - compatibility-matrix
+      - integration
+      - publish
+    if: >
+      always() &&
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main' &&
+      needs.plan.result == 'success' &&
+      needs.plan.outputs.release_needed == 'true' &&
+      needs.plan.outputs.dry_run == 'false'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.11"
+      - name: Create, update, or close release failure issue
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          python scripts/track_workflow_failure.py release \
+            --repository "${{ github.repository }}" \
+            --token "$GITHUB_TOKEN" \
+            --workflow-name "${{ github.workflow }}" \
+            --run-url "$RUN_URL" \
+            --branch "${{ github.ref_name }}" \
+            --source-pr "${{ needs.plan.outputs.source_pr }}" \
+            --source-sha "${{ needs.plan.outputs.source_sha }}" \
+            --release-type "${{ needs.plan.outputs.release_type }}" \
+            --planned-version "${{ needs.plan.outputs.next_version }}" \
+            --compatibility-result "${{ needs.compatibility-matrix.result }}" \
+            --integration-result "${{ needs.integration.result }}" \
+            --publish-result "${{ needs.publish.result }}" \
+            --release-complete "${{ needs.publish.outputs.release_complete }}"

--- a/scripts/track_workflow_failure.py
+++ b/scripts/track_workflow_failure.py
@@ -1,0 +1,456 @@
+#!/usr/bin/env python3
+"""Track post-merge workflow failures with deduplicated GitHub issues."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ISSUE_LABELS = {
+    "ci-flake": ("flake", "ci", "triage"),
+    "code-regression": ("ci", "triage"),
+    "infra-flake": ("ci", "triage"),
+    "pr-failure": ("ci", "triage"),
+    "release-blocked": ("release-blocked", "ci", "triage"),
+    "security-blocker": ("security-blocker", "ci", "triage"),
+    "publish-partial": ("publish-partial", "ci", "triage"),
+}
+
+LABEL_COLORS = {
+    "ci": "ededed",
+    "triage": "ededed",
+    "flake": "d4c5f9",
+    "release-blocked": "b60205",
+    "publish-partial": "fbca04",
+    "security-blocker": "d93f0b",
+}
+
+
+@dataclass(frozen=True)
+class FailureRecord:
+    repository: str
+    workflow: str
+    failed_stage: str
+    failure_class: str
+    signature: str
+    run_url: str
+    source_sha: str
+    branch: str
+    source_pr: str = ""
+    release_type: str = ""
+    planned_version: str = ""
+    next_action: str = ""
+
+    @property
+    def key(self) -> str:
+        source = "/".join(
+            [self.workflow, self.failed_stage, self.failure_class, self.signature]
+        )
+        return hashlib.sha256(source.encode("utf-8")).hexdigest()[:16]
+
+
+class GitHubClient:
+    def __init__(self, repository: str, token: str) -> None:
+        self.repository = repository
+        self.token = token
+
+    def request(
+        self, method: str, path: str, payload: dict[str, Any] | None = None
+    ) -> Any:
+        data = None
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {self.token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        if payload is not None:
+            data = json.dumps(payload).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+
+        request = urllib.request.Request(
+            f"https://api.github.com{path}",
+            data=data,
+            headers=headers,
+            method=method,
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:  # noqa: S310
+                body = response.read().decode("utf-8")
+        except urllib.error.HTTPError as exc:
+            body = exc.read().decode("utf-8", errors="replace")
+            raise RuntimeError(f"GitHub API request failed: {exc.code} {body}") from exc
+
+        return json.loads(body) if body else {}
+
+    def search_open_issues(
+        self, labels: tuple[str, ...], key: str
+    ) -> list[dict[str, Any]]:
+        terms = [
+            f"repo:{self.repository}",
+            "is:issue",
+            "is:open",
+            f'"failure-key: {key}"',
+        ]
+        terms.extend(f"label:{label}" for label in labels)
+        query = urllib.parse.urlencode({"q": " ".join(terms)})
+        payload = self.request("GET", f"/search/issues?{query}")
+        items = payload.get("items") if isinstance(payload, dict) else []
+        return [item for item in items if isinstance(item, dict)]
+
+    def search_open_issues_by_text(
+        self, labels: tuple[str, ...], text: str
+    ) -> list[dict[str, Any]]:
+        terms = [f"repo:{self.repository}", "is:issue", "is:open", f'"{text}"']
+        terms.extend(f"label:{label}" for label in labels)
+        query = urllib.parse.urlencode({"q": " ".join(terms)})
+        payload = self.request("GET", f"/search/issues?{query}")
+        items = payload.get("items") if isinstance(payload, dict) else []
+        return [item for item in items if isinstance(item, dict)]
+
+    def create_issue(
+        self, title: str, body: str, labels: tuple[str, ...]
+    ) -> dict[str, Any]:
+        self.ensure_labels(labels)
+        return self.request(
+            "POST",
+            f"/repos/{self.repository}/issues",
+            {"title": title, "body": body, "labels": list(labels)},
+        )
+
+    def ensure_labels(self, labels: tuple[str, ...]) -> None:
+        for label in labels:
+            payload = {
+                "name": label,
+                "color": LABEL_COLORS.get(label, "ededed"),
+            }
+            try:
+                self.request("POST", f"/repos/{self.repository}/labels", payload)
+            except RuntimeError as exc:
+                if "422" not in str(exc):
+                    raise
+
+    def comment_issue(self, issue_number: int, body: str) -> dict[str, Any]:
+        return self.request(
+            "POST",
+            f"/repos/{self.repository}/issues/{issue_number}/comments",
+            {"body": body},
+        )
+
+    def close_issue(self, issue_number: int) -> dict[str, Any]:
+        return self.request(
+            "PATCH",
+            f"/repos/{self.repository}/issues/{issue_number}",
+            {"state": "closed", "state_reason": "completed"},
+        )
+
+    def workflow_runs(
+        self, workflow_file: str, branch: str, status: str, per_page: int = 10
+    ) -> list[dict[str, Any]]:
+        query = urllib.parse.urlencode(
+            {"branch": branch, "status": status, "per_page": str(per_page)}
+        )
+        payload = self.request(
+            "GET",
+            f"/repos/{self.repository}/actions/workflows/{workflow_file}/runs?{query}",
+        )
+        runs = payload.get("workflow_runs") if isinstance(payload, dict) else []
+        return [run for run in runs if isinstance(run, dict)]
+
+
+def classify_failure(event_name: str, failed_stage: str, publish_partial: bool) -> str:
+    normalized_stage = failed_stage.lower()
+    if event_name == "pull_request":
+        return "pr-failure"
+    if publish_partial:
+        return "publish-partial"
+    if "security" in normalized_stage:
+        return "security-blocker"
+    if "release" in normalized_stage or "integration" in normalized_stage:
+        return "release-blocked"
+    if event_name in {"schedule", "workflow_dispatch"}:
+        return "ci-flake"
+    if event_name == "push":
+        return "code-regression"
+    return "infra-flake"
+
+
+def issue_title(record: FailureRecord) -> str:
+    if record.failure_class == "ci-flake":
+        return f"[Flake] {record.workflow} failed at {record.failed_stage}"
+    if record.failure_class == "publish-partial":
+        return f"[Release] Partial publish for {record.planned_version}"
+    if record.failure_class == "release-blocked":
+        return f"[Release] {record.planned_version} blocked at {record.failed_stage}"
+    return f"[CI] {record.workflow} failed at {record.failed_stage}"
+
+
+def issue_body(record: FailureRecord, now: str) -> str:
+    return f"""<!-- failure-key: {record.key} -->
+
+## Failure tracking
+
+- Failure key: `{record.key}`
+- Failure class: `{record.failure_class}`
+- Workflow: `{record.workflow}`
+- Failed stage: `{record.failed_stage}`
+- Run URL: {record.run_url}
+- Source PR: {record.source_pr or "n/a"}
+- Source SHA: `{record.source_sha}`
+- Branch: `{record.branch}`
+- Release type: `{record.release_type or "n/a"}`
+- Planned version: `{record.planned_version or "n/a"}`
+- First seen: `{now}`
+- Latest seen: `{now}`
+
+## Required action
+
+{record.next_action}
+"""
+
+
+def update_comment(record: FailureRecord, now: str) -> str:
+    return f"""Latest occurrence for `{record.key}`:
+
+- Time: `{now}`
+- Run URL: {record.run_url}
+- Source SHA: `{record.source_sha}`
+- Failed stage: `{record.failed_stage}`
+- Failure class: `{record.failure_class}`
+- Next action: {record.next_action}
+"""
+
+
+def append_summary(record: FailureRecord, issue_url: str, action: str) -> None:
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+
+    with Path(summary_path).open("a", encoding="utf-8") as summary:
+        summary.write("## Failure tracking\n\n")
+        summary.write(f"- source PR: `{record.source_pr or 'n/a'}`\n")
+        summary.write(f"- source SHA: `{record.source_sha}`\n")
+        summary.write(f"- failed stage: `{record.failed_stage}`\n")
+        summary.write(f"- failure class: `{record.failure_class}`\n")
+        summary.write(f"- failure key: `{record.key}`\n")
+        summary.write(f"- issue URL: {issue_url or 'n/a'}\n")
+        summary.write(f"- next action: {record.next_action}\n")
+        summary.write(f"- automation action: `{action}`\n")
+
+
+def ensure_issue(client: GitHubClient, record: FailureRecord) -> str:
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    labels = ISSUE_LABELS[record.failure_class]
+    matches = client.search_open_issues(labels, record.key)
+    if matches:
+        issue = matches[0]
+        number = int(issue["number"])
+        client.comment_issue(number, update_comment(record, now))
+        url = str(issue.get("html_url") or issue.get("url") or "")
+        append_summary(record, url, "updated")
+        return url
+
+    issue = client.create_issue(issue_title(record), issue_body(record, now), labels)
+    url = str(issue.get("html_url") or issue.get("url") or "")
+    append_summary(record, url, "created")
+    return url
+
+
+def close_matching_issues(client: GitHubClient, record: FailureRecord) -> list[str]:
+    closed: list[str] = []
+    seen: set[int] = set()
+    for failure_class in ("release-blocked", "publish-partial"):
+        labels = ISSUE_LABELS[failure_class]
+        matches = client.search_open_issues_by_text(labels, record.planned_version)
+        for issue in matches:
+            number = int(issue["number"])
+            if number in seen:
+                continue
+            seen.add(number)
+            client.comment_issue(
+                number,
+                f"Closing after a successful release run: {record.run_url}",
+            )
+            client.close_issue(number)
+            closed.append(str(issue.get("html_url") or issue.get("url") or ""))
+    return closed
+
+
+def previous_failed_runs(
+    client: GitHubClient, workflow_file: str, branch: str, current_run_id: str
+) -> int:
+    runs = client.workflow_runs(workflow_file, branch, "failure", per_page=10)
+    return sum(str(run.get("id") or "") != current_run_id for run in runs)
+
+
+def release_record(
+    args: argparse.Namespace, failure_class: str, stage: str
+) -> FailureRecord:
+    return FailureRecord(
+        repository=args.repository,
+        workflow=args.workflow_name,
+        failed_stage=stage,
+        failure_class=failure_class,
+        signature=f"{args.workflow_name}:{stage}:{args.release_type}:{args.planned_version}",
+        run_url=args.run_url,
+        source_sha=args.source_sha,
+        branch=args.branch,
+        source_pr=args.source_pr,
+        release_type=args.release_type,
+        planned_version=args.planned_version,
+        next_action=(
+            "Inspect the failed release stage, rerun if it was infrastructure-only, "
+            "or fix forward with a new PR."
+        ),
+    )
+
+
+def handle_release(args: argparse.Namespace) -> int:
+    client = GitHubClient(args.repository, args.token)
+    results = {
+        "compatibility-matrix": args.compatibility_result,
+        "integration": args.integration_result,
+        "publish": args.publish_result,
+    }
+
+    if "cancelled" in results.values():
+        print("Release failure tracking skipped for cancelled workflow.")
+        return 0
+
+    if args.compatibility_result != "success":
+        record = release_record(args, "release-blocked", "compatibility-matrix")
+        ensure_issue(client, record)
+        return 0
+
+    if args.integration_result != "success":
+        record = release_record(args, "release-blocked", "integration")
+        ensure_issue(client, record)
+        return 0
+
+    if args.publish_result == "success" and args.release_complete == "true":
+        record = release_record(args, "release-blocked", "release")
+        closed = close_matching_issues(client, record)
+        append_summary(record, ", ".join(closed), "closed" if closed else "none")
+        print(f"Closed {len(closed)} release failure issue(s).")
+        return 0
+
+    if args.publish_result == "success":
+        record = release_record(args, "publish-partial", "publish")
+        record = FailureRecord(
+            **{
+                **record.__dict__,
+                "next_action": "Publish job succeeded without a verified release completion signal; keep release incidents open until PyPI and GitHub Release state are verified.",
+            }
+        )
+        append_summary(record, "", "not-closed")
+        print(
+            "Release issue closure skipped because release completion was not verified."
+        )
+        return 0
+
+    if args.publish_result == "failure":
+        record = release_record(args, "publish-partial", "publish")
+        record = FailureRecord(
+            **{
+                **record.__dict__,
+                "next_action": "Check tag, GitHub Release, PyPI, and verification state; fix forward if any artifact is already public.",
+            }
+        )
+        ensure_issue(client, record)
+        return 0
+
+    print("Release failure tracking found no actionable failure.")
+    return 0
+
+
+def handle_ci(args: argparse.Namespace) -> int:
+    failure_class = classify_failure(args.event_name, args.failed_stage, False)
+    record = FailureRecord(
+        repository=args.repository,
+        workflow=args.workflow_name,
+        failed_stage=args.failed_stage,
+        failure_class=failure_class,
+        signature=f"{args.workflow_file}:{args.failed_stage}:{args.branch}",
+        run_url=args.run_url,
+        source_sha=args.source_sha,
+        branch=args.branch,
+        next_action="Rerun if infrastructure-related; otherwise fix forward on main.",
+    )
+
+    if failure_class == "pr-failure":
+        append_summary(record, "", "summary-only")
+        print("PR failure recorded in summary only.")
+        return 0
+
+    client = GitHubClient(args.repository, args.token)
+    if failure_class == "ci-flake":
+        previous_failures = previous_failed_runs(
+            client, args.workflow_file, args.branch, args.run_id
+        )
+        if previous_failures < args.min_previous_failures:
+            append_summary(record, "", "summary-only")
+            print("First observed flake; no issue created.")
+            return 0
+
+    ensure_issue(client, record)
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    release = subparsers.add_parser("release")
+    release.add_argument("--repository", required=True)
+    release.add_argument("--token", required=True)
+    release.add_argument("--workflow-name", required=True)
+    release.add_argument("--run-url", required=True)
+    release.add_argument("--branch", required=True)
+    release.add_argument("--source-pr", default="")
+    release.add_argument("--source-sha", required=True)
+    release.add_argument("--release-type", required=True)
+    release.add_argument("--planned-version", required=True)
+    release.add_argument("--compatibility-result", required=True)
+    release.add_argument("--integration-result", required=True)
+    release.add_argument("--publish-result", required=True)
+    release.add_argument("--release-complete", default="")
+    release.set_defaults(func=handle_release)
+
+    ci = subparsers.add_parser("ci")
+    ci.add_argument("--repository", required=True)
+    ci.add_argument("--token", required=True)
+    ci.add_argument("--workflow-name", required=True)
+    ci.add_argument("--workflow-file", required=True)
+    ci.add_argument("--run-id", required=True)
+    ci.add_argument("--run-url", required=True)
+    ci.add_argument("--branch", required=True)
+    ci.add_argument("--source-sha", required=True)
+    ci.add_argument("--event-name", required=True)
+    ci.add_argument("--failed-stage", required=True)
+    ci.add_argument("--min-previous-failures", type=int, default=1)
+    ci.set_defaults(func=handle_ci)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return int(args.func(args))
+    except Exception as exc:
+        print(f"Failure tracking failed: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_track_workflow_failure.py
+++ b/tests/scripts/test_track_workflow_failure.py
@@ -1,0 +1,195 @@
+import importlib.util
+import sys
+from argparse import Namespace
+from pathlib import Path
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2] / "scripts" / "track_workflow_failure.py"
+)
+SPEC = importlib.util.spec_from_file_location("track_workflow_failure", SCRIPT_PATH)
+assert SPEC is not None
+track_workflow_failure = importlib.util.module_from_spec(SPEC)
+sys.modules["track_workflow_failure"] = track_workflow_failure
+assert SPEC.loader is not None
+SPEC.loader.exec_module(track_workflow_failure)
+
+
+class FakeClient:
+    def __init__(self, matches=None, runs=None):
+        self.matches = matches or []
+        self.runs = runs or []
+        self.created = []
+        self.comments = []
+        self.closed = []
+        self.ensured_labels = []
+
+    def search_open_issues(self, labels, key):
+        self.last_search = (labels, key)
+        return self.matches
+
+    def search_open_issues_by_text(self, labels, text):
+        self.last_text_search = (labels, text)
+        return self.matches
+
+    def create_issue(self, title, body, labels):
+        self.ensure_labels(labels)
+        issue = {
+            "number": 123,
+            "html_url": "https://github.example/issues/123",
+            "title": title,
+            "body": body,
+            "labels": labels,
+        }
+        self.created.append(issue)
+        return issue
+
+    def ensure_labels(self, labels):
+        self.ensured_labels.extend(labels)
+
+    def comment_issue(self, issue_number, body):
+        self.comments.append((issue_number, body))
+        return {}
+
+    def close_issue(self, issue_number):
+        self.closed.append(issue_number)
+        return {}
+
+    def workflow_runs(self, workflow_file, branch, status, per_page=10):
+        self.last_runs_request = (workflow_file, branch, status, per_page)
+        return self.runs
+
+
+def record(**overrides):
+    values = {
+        "repository": "stratza/spindlex",
+        "workflow": "Release",
+        "failed_stage": "integration",
+        "failure_class": "release-blocked",
+        "signature": "Release:integration:patch:0.6.7",
+        "run_url": "https://github.example/runs/1",
+        "source_sha": "abc123",
+        "branch": "main",
+        "source_pr": "131",
+        "release_type": "patch",
+        "planned_version": "0.6.7",
+        "next_action": "Fix forward.",
+    }
+    values.update(overrides)
+    return track_workflow_failure.FailureRecord(**values)
+
+
+def test_failure_key_is_stable():
+    first = record().key
+    second = record().key
+
+    assert first == second
+    assert len(first) == 16
+
+
+def test_classifies_pull_request_as_summary_only_failure():
+    failure_class = track_workflow_failure.classify_failure(
+        "pull_request", "unit-tests", False
+    )
+
+    assert failure_class == "pr-failure"
+
+
+def test_classifies_publish_partial_before_release_blocked():
+    failure_class = track_workflow_failure.classify_failure("push", "publish", True)
+
+    assert failure_class == "publish-partial"
+
+
+def test_ensure_issue_creates_when_no_match(monkeypatch):
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+    client = FakeClient()
+
+    url = track_workflow_failure.ensure_issue(client, record())
+
+    assert url == "https://github.example/issues/123"
+    assert client.created
+    assert "failure-key" in client.created[0]["body"]
+    assert "release-blocked" in client.created[0]["labels"]
+    assert "release-blocked" in client.ensured_labels
+
+
+def test_ensure_issue_updates_existing_match(monkeypatch):
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+    client = FakeClient(
+        matches=[{"number": 45, "html_url": "https://github.example/issues/45"}]
+    )
+
+    url = track_workflow_failure.ensure_issue(client, record())
+
+    assert url == "https://github.example/issues/45"
+    assert not client.created
+    assert client.comments[0][0] == 45
+
+
+def test_close_matching_issues_uses_planned_version():
+    client = FakeClient(
+        matches=[{"number": 78, "html_url": "https://github.example/issues/78"}]
+    )
+
+    closed = track_workflow_failure.close_matching_issues(client, record())
+
+    assert closed == ["https://github.example/issues/78"]
+    assert client.closed == [78]
+    assert client.last_text_search[1] == "0.6.7"
+
+
+def test_previous_failed_runs_excludes_current_run():
+    client = FakeClient(runs=[{"id": 1}, {"id": 2}, {"id": 3}])
+
+    count = track_workflow_failure.previous_failed_runs(
+        client, "ci-matrix.yml", "main", "2"
+    )
+
+    assert count == 2
+
+
+def release_args(**overrides):
+    values = {
+        "repository": "stratza/spindlex",
+        "token": "token",
+        "workflow_name": "Release",
+        "run_url": "https://github.example/runs/1",
+        "branch": "main",
+        "source_pr": "131",
+        "source_sha": "abc123",
+        "release_type": "patch",
+        "planned_version": "0.6.7",
+        "compatibility_result": "success",
+        "integration_result": "success",
+        "publish_result": "success",
+        "release_complete": "true",
+    }
+    values.update(overrides)
+    return Namespace(**values)
+
+
+def test_handle_release_closes_only_when_release_completion_is_verified(monkeypatch):
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+    client = FakeClient(
+        matches=[{"number": 78, "html_url": "https://github.example/issues/78"}]
+    )
+    monkeypatch.setattr(track_workflow_failure, "GitHubClient", lambda *_: client)
+
+    result = track_workflow_failure.handle_release(release_args())
+
+    assert result == 0
+    assert client.closed == [78]
+
+
+def test_handle_release_does_not_close_when_publish_skipped_existing_tag(monkeypatch):
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+    client = FakeClient(
+        matches=[{"number": 78, "html_url": "https://github.example/issues/78"}]
+    )
+    monkeypatch.setattr(track_workflow_failure, "GitHubClient", lambda *_: client)
+
+    result = track_workflow_failure.handle_release(release_args(release_complete=""))
+
+    assert result == 0
+    assert client.closed == []
+    assert client.comments == []


### PR DESCRIPTION
## Description

Adds failure-tracking automation for post-merge CI and release workflows.

Fixes #131

## Type of Change

Select exactly one option. These stable tokens are parsed by CI and release automation.

- [ ] bug - Bug fix; creates a patch release.
- [ ] feature - New feature; creates a minor release.
- [ ] breaking - Breaking change; creates a major release.
- [ ] docs - Documentation-only change; no release.
- [x] refactor - Non-functional cleanup or refactor; no release.
- [ ] test - Test-only change; no release.

## How Has This Been Tested?

- [x] **Unit Tests**: `.venv/bin/python -m pytest tests/scripts/test_track_workflow_failure.py tests/scripts/test_release_helpers.py tests/scripts/test_validate_pr_body.py tests/scripts/test_check_changelog_updated.py`
- [ ] **Integration Tests**: `pytest -m integration`
- [x] **Manual Test**: ran Ruff check/format on the new helper, compiled `scripts/*.py`, and verified `git diff --check`.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
