### PR TITLE
security: tighten dependency audit policy

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -108,6 +108,16 @@ jobs:
       - run: semgrep scan --config p/python --config p/security-audit --metrics=off --severity ERROR --error spindlex
       - run: python scripts/export_runtime_requirements.py --output runtime-requirements.txt
       - run: pip-audit -r runtime-requirements.txt --cache-dir .pip-audit-cache
+      - name: Runtime dependency license audit
+        run: |
+          python -m venv .license-audit-venv
+          .license-audit-venv/bin/python -m pip install --upgrade pip
+          .license-audit-venv/bin/python -m pip install -r runtime-requirements.txt
+          .license-audit-venv/bin/python scripts/check_dependency_licenses.py \
+            --exclude pip \
+            --exclude setuptools \
+            --exclude wheel \
+            --fail-on-unknown
       - run: |
           docker run --rm \
             -v "$PWD:/repo" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ on:
       - ".github/workflows/ci-matrix.yml"
       - ".github/workflows/integration.yml"
       - ".github/ISSUE_TEMPLATE/**"
+      - "scripts/extract_release_notes.py"
       - "scripts/plan_release.py"
       - "scripts/sync_project_version.py"
       - "scripts/track_workflow_failure.py"
@@ -279,10 +280,19 @@ jobs:
           git tag -a "$TAG" -m "Release $TAG"
           git push origin "$TAG"
 
-          cat > release-notes.md <<EOF
-          Source PR: #$SOURCE_PR $SOURCE_PR_URL
-          Release type: $RELEASE_TYPE
-          EOF
+          python scripts/extract_release_notes.py \
+            --version "${{ needs.plan.outputs.next_version }}" \
+            --output release-notes.md
+
+          {
+            echo ""
+            echo "---"
+            echo ""
+            echo "Source PR: #$SOURCE_PR $SOURCE_PR_URL"
+            echo "Release type: $RELEASE_TYPE"
+            echo ""
+            echo "**Full Changelog:** https://github.com/${{ github.repository }}/blob/main/docs/changelog.md"
+          } >> release-notes.md
 
           gh release create "$TAG" \
             --title "$TAG" \

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -63,12 +63,30 @@ jobs:
             --cache-dir .pip-audit-cache \
             --format json \
             --output pip-audit.json
+      - name: Run runtime license audit
+        run: |
+          python -m venv .license-audit-venv
+          .license-audit-venv/bin/python -m pip install --upgrade pip
+          .license-audit-venv/bin/python -m pip install -r runtime-requirements.txt
+          .license-audit-venv/bin/python scripts/check_dependency_licenses.py \
+            --exclude pip \
+            --exclude setuptools \
+            --exclude wheel \
+            --fail-on-unknown \
+            --output dependency-licenses.json
       - name: Upload pip-audit report
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: pip-audit-report
           path: pip-audit.json
+          if-no-files-found: ignore
+      - name: Upload dependency license report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: dependency-license-report
+          path: dependency-licenses.json
           if-no-files-found: ignore
 
   gitleaks:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,49 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.7] - 2026-05-05
+
+### Summary
+This release hardens the project lifecycle around release automation, PR gates, security scanning, and incident triage. It resolves the Scorecard/OSV dependency findings reported after v0.6.6, adds corporate-oriented runtime dependency license checks, and turns the CI/CD system into the main release safety surface for future patch releases.
+
+### Security
+*   Raised the minimum supported `cryptography` version to `>=46.0.6`, avoiding the vulnerable ranges reported by OSV/Scorecard for the runtime dependency.
+*   Raised documentation dependency floors for `pymdown-extensions>=10.16.1` and `pygments>=2.20.0` to avoid known vulnerable documentation-build dependency ranges.
+*   Added a runtime dependency license audit to the PR gate and scheduled security workflow. The audit fails on denied corporate-risk licenses such as GPL, LGPL, AGPL, SSPL, BUSL, and proprietary/commercial markers, and uploads a dependency license report from the full security workflow.
+*   Added a full scheduled security workflow covering Semgrep, pip-audit, Gitleaks, Trivy, CodeQL SARIF upload, and OpenSSF Scorecard.
+*   Documented project security policy and vulnerability reporting expectations in public and maintainer-facing security docs.
+*   Kept legacy `ssh-rsa` SHA-1 handling explicitly gated behind `allow_sha1=True` while adding scanner suppressions that document the intentional compatibility path.
+
+### CI/CD
+*   Added a fast PR gate with stable PR type parsing, ruff, mypy, unit tests, docs build, workflow linting, security checks, and an aggregate quality gate.
+*   Split compatibility and Docker-backed integration checks into reusable workflows used by both PR validation and release dry runs.
+*   Added Linux Python 3.9-3.13 coverage plus Windows and macOS smoke coverage for the compatibility matrix.
+*   Added full SHA pin dereferencing for GitHub Actions usage and tightened code-scanning-friendly workflow configuration.
+*   Updated Trivy action usage and fixed Scorecard workflow permissions.
+*   Removed legacy duplicated CI and release helper entry points in favor of the root `Makefile` and the dedicated reusable workflows.
+
+### Release Automation
+*   Added PR-driven release planning that maps PR type checkboxes to patch, minor, major, or no-release outcomes.
+*   Added release dry-run validation for PRs so release planning, version sync, build, and publish checks are exercised before merge.
+*   Added changelog enforcement for release-producing PRs so bug, feature, and breaking changes cannot merge without changelog updates.
+*   Added changelog-section extraction for GitHub Release notes so automated releases keep the same detailed release-note shape as previous manual releases.
+*   Added workflow failure tracking that opens or updates CI failure, flaky pipeline, and release-blocked incident issues with structured templates.
+*   Added release publish and partial-publish triage hooks to preserve release failure context for maintainers.
+
+### Documentation
+*   Moved internal lifecycle planning docs out of the public documentation site and into `meta/internal/lifecycle`.
+*   Added lifecycle epics, stage gates, release-process epics, quality/security epics, product-readiness epics, release-candidate planning, operations epics, failure-handling guidance, and implementation roadmap docs.
+*   Updated contributing docs and PR guidance to match the new stable PR type tokens and release automation.
+*   Refreshed badges and operational references after the workflow cleanup.
+
+### Tests
+*   Added tests for PR body validation, release planning/version sync, changelog enforcement, workflow failure tracking, and dependency license policy checks.
+*   Added `pytest-timeout` to the test tooling used by the split CI workflows.
+
+### Removed
+*   Removed the legacy `.github/workflows/ci.yml` workflow after the PR gate, matrix, integration, release, and security workflows took over its responsibilities.
+*   Removed obsolete `scripts/release.py`, `scripts/build.sh`, and `scripts/Makefile` helpers.
+
 ## [0.6.6] - 2026-05-01
 
 ### Summary

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,5 +4,5 @@ mkdocs-material>=9.1.0
 mkdocstrings[python]>=0.22.0
 mkdocs-minify-plugin>=0.6.0
 mkdocs-git-revision-date-localized-plugin>=1.2.0
-pymdown-extensions>=10.0
-pygments>=2.15.0
+pymdown-extensions>=10.16.1
+pygments>=2.20.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "cryptography>=41.0.0",
+    "cryptography>=46.0.6",
     "typing-extensions>=4.0.0; python_version<'3.10'",
 ]
 
@@ -72,8 +72,8 @@ docs = [
     "mkdocstrings[python]>=0.22.0",
     "mkdocs-minify-plugin>=0.6.0",
     "mkdocs-git-revision-date-localized-plugin>=1.2.0",
-    "pymdown-extensions>=10.0",
-    "pygments>=2.15.0",
+    "pymdown-extensions>=10.16.1",
+    "pygments>=2.20.0",
 ]
 test = [
     "pytest>=7.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-cryptography>=41.0.0
+cryptography>=46.0.6
 typing-extensions>=4.15.0; python_version<'3.10'

--- a/scripts/check_dependency_licenses.py
+++ b/scripts/check_dependency_licenses.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Fail when installed dependency licenses match the project deny policy."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.metadata as metadata
+import json
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable
+
+DEFAULT_DENIED_LICENSES = (
+    "AGPL",
+    "BUSL",
+    "CDDL",
+    "COMMERCIAL",
+    "CPL",
+    "EPL",
+    "EUPL",
+    "GPL",
+    "LGPL",
+    "OSL",
+    "PROPRIETARY",
+    "SSPL",
+)
+
+
+@dataclass(frozen=True)
+class LicenseFinding:
+    name: str
+    version: str
+    license_expression: str
+    license_text: str
+    classifiers: list[str]
+    denied_matches: list[str]
+    unknown_license: bool
+
+
+def canonical_name(name: str) -> str:
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def denied_matches(evidence: Iterable[str], denied: Iterable[str]) -> list[str]:
+    matches: set[str] = set()
+    evidence_text = "\n".join(value for value in evidence if value).upper()
+
+    for license_name in denied:
+        token = re.escape(license_name.upper())
+        pattern = re.compile(rf"(?<![A-Z0-9]){token}(?=$|[^A-Z0-9]|V[0-9])")
+        if pattern.search(evidence_text):
+            matches.add(license_name.upper())
+
+    return sorted(matches)
+
+
+def distribution_finding(
+    distribution: metadata.Distribution,
+    denied: Iterable[str],
+) -> LicenseFinding:
+    package_metadata = distribution.metadata
+    name = package_metadata.get("Name", distribution.name)
+    version = package_metadata.get("Version", distribution.version)
+    license_expression = package_metadata.get("License-Expression", "")
+    license_text = package_metadata.get("License", "")
+    classifiers = package_metadata.get_all("Classifier") or []
+    license_classifiers = [
+        classifier for classifier in classifiers if classifier.startswith("License ::")
+    ]
+    evidence = [license_expression, license_text, *license_classifiers]
+    unknown_license = not any(value.strip() for value in evidence)
+
+    return LicenseFinding(
+        name=name,
+        version=version,
+        license_expression=license_expression,
+        license_text=license_text,
+        classifiers=license_classifiers,
+        denied_matches=denied_matches(evidence, denied),
+        unknown_license=unknown_license,
+    )
+
+
+def scan_installed_distributions(
+    denied: Iterable[str],
+    excluded_packages: Iterable[str],
+) -> list[LicenseFinding]:
+    excluded = {canonical_name(name) for name in excluded_packages}
+    findings = []
+
+    for distribution in metadata.distributions():
+        finding = distribution_finding(distribution, denied)
+        if canonical_name(finding.name) in excluded:
+            continue
+        findings.append(finding)
+
+    return sorted(findings, key=lambda finding: canonical_name(finding.name))
+
+
+def write_report(path: Path, findings: list[LicenseFinding]) -> None:
+    payload = {
+        "dependencies": [asdict(finding) for finding in findings],
+    }
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--deny",
+        action="append",
+        default=[],
+        help="Denied license token. Defaults to the project deny policy.",
+    )
+    parser.add_argument(
+        "--exclude",
+        action="append",
+        default=[],
+        help="Installed package name to exclude from evaluation.",
+    )
+    parser.add_argument(
+        "--fail-on-unknown",
+        action="store_true",
+        help="Fail dependencies that do not expose license metadata.",
+    )
+    parser.add_argument("--output", type=Path, help="Optional JSON report path.")
+    args = parser.parse_args(argv)
+
+    denied = args.deny or list(DEFAULT_DENIED_LICENSES)
+    findings = scan_installed_distributions(denied, args.exclude)
+    failing = [
+        finding
+        for finding in findings
+        if finding.denied_matches or (args.fail_on_unknown and finding.unknown_license)
+    ]
+
+    if args.output:
+        write_report(args.output, findings)
+
+    if failing:
+        print("Dependency license policy violations detected:")
+        for finding in failing:
+            reason = (
+                ", ".join(finding.denied_matches)
+                if finding.denied_matches
+                else "missing license metadata"
+            )
+            print(f"- {finding.name} {finding.version}: {reason}")
+        return 1
+
+    print(f"Checked {len(findings)} installed distributions; no denied licenses found.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/extract_release_notes.py
+++ b/scripts/extract_release_notes.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Extract one release section from docs/changelog.md."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+DEFAULT_CHANGELOG = Path("docs/changelog.md")
+RELEASE_HEADING = re.compile(r"^## \[(?P<version>[^\]]+)\](?:\s+-\s+.*)?$")
+
+
+def extract_release_notes(changelog: Path, version: str) -> str:
+    lines = changelog.read_text(encoding="utf-8").splitlines()
+    start: int | None = None
+    end = len(lines)
+
+    for index, line in enumerate(lines):
+        match = RELEASE_HEADING.match(line)
+        if not match:
+            continue
+        if match.group("version") == version:
+            start = index + 1
+            continue
+        if start is not None:
+            end = index
+            break
+
+    if start is None:
+        raise ValueError(f"Could not find changelog section for version {version}.")
+
+    notes = "\n".join(lines[start:end]).strip()
+    if not notes:
+        raise ValueError(f"Changelog section for version {version} is empty.")
+    return notes + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--changelog", type=Path, default=DEFAULT_CHANGELOG)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args(argv)
+
+    try:
+        notes = extract_release_notes(args.changelog, args.version)
+    except Exception as exc:
+        print(f"Release note extraction failed: {exc}", file=sys.stderr)
+        return 1
+
+    args.output.write_text(notes, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_check_dependency_licenses.py
+++ b/tests/scripts/test_check_dependency_licenses.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from email.message import Message
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parents[2] / "scripts"
+
+
+def load_script(name: str):
+    path = SCRIPT_DIR / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+check_dependency_licenses = load_script("check_dependency_licenses")
+
+
+class FakeDistribution:
+    def __init__(
+        self,
+        name: str,
+        version: str = "1.0.0",
+        license_expression: str = "",
+        license_text: str = "",
+        classifiers: list[str] | None = None,
+    ) -> None:
+        self.metadata = Message()
+        self.metadata["Name"] = name
+        self.metadata["Version"] = version
+        if license_expression:
+            self.metadata["License-Expression"] = license_expression
+        if license_text:
+            self.metadata["License"] = license_text
+        for classifier in classifiers or []:
+            self.metadata["Classifier"] = classifier
+
+    @property
+    def name(self) -> str:
+        return self.metadata["Name"]
+
+    @property
+    def version(self) -> str:
+        return self.metadata["Version"]
+
+
+def test_permissive_license_expression_passes():
+    finding = check_dependency_licenses.distribution_finding(
+        FakeDistribution(
+            "cryptography", license_expression="Apache-2.0 OR BSD-3-Clause"
+        ),
+        check_dependency_licenses.DEFAULT_DENIED_LICENSES,
+    )
+
+    assert finding.denied_matches == []
+    assert finding.unknown_license is False
+
+
+def test_denied_license_classifier_fails():
+    finding = check_dependency_licenses.distribution_finding(
+        FakeDistribution(
+            "copyleft-package",
+            classifiers=[
+                "License :: OSI Approved :: GNU General Public License v3 (GPLv3)"
+            ],
+        ),
+        check_dependency_licenses.DEFAULT_DENIED_LICENSES,
+    )
+
+    assert finding.denied_matches == ["GPL"]
+
+
+def test_lgpl_does_not_report_plain_gpl_match():
+    finding = check_dependency_licenses.distribution_finding(
+        FakeDistribution("weak-copyleft", license_expression="LGPL-3.0-only"),
+        check_dependency_licenses.DEFAULT_DENIED_LICENSES,
+    )
+
+    assert finding.denied_matches == ["LGPL"]
+
+
+def test_missing_license_metadata_is_unknown():
+    finding = check_dependency_licenses.distribution_finding(
+        FakeDistribution("unknown-package"),
+        check_dependency_licenses.DEFAULT_DENIED_LICENSES,
+    )
+
+    assert finding.denied_matches == []
+    assert finding.unknown_license is True
+
+
+def test_scan_excludes_bootstrap_packages(monkeypatch):
+    distributions = [
+        FakeDistribution("pip", license_expression="MIT"),
+        FakeDistribution("Runtime_Dep", license_expression="MIT"),
+    ]
+    monkeypatch.setattr(
+        check_dependency_licenses.metadata,
+        "distributions",
+        lambda: distributions,
+    )
+
+    findings = check_dependency_licenses.scan_installed_distributions(
+        check_dependency_licenses.DEFAULT_DENIED_LICENSES,
+        ["PIP"],
+    )
+
+    assert [finding.name for finding in findings] == ["Runtime_Dep"]

--- a/tests/scripts/test_extract_release_notes.py
+++ b/tests/scripts/test_extract_release_notes.py
@@ -1,0 +1,74 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parents[2] / "scripts"
+
+
+def load_script(name: str):
+    path = SCRIPT_DIR / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+extract_release_notes = load_script("extract_release_notes")
+
+
+def test_extracts_requested_release_section(tmp_path):
+    changelog = tmp_path / "changelog.md"
+    changelog.write_text(
+        """# Changelog
+
+## [1.2.3] - 2026-05-05
+
+### Fixed
+*   Patched dependency metadata.
+
+## [1.2.2] - 2026-05-01
+
+### Fixed
+*   Older change.
+""",
+        encoding="utf-8",
+    )
+
+    notes = extract_release_notes.extract_release_notes(changelog, "1.2.3")
+
+    assert notes == "### Fixed\n*   Patched dependency metadata.\n"
+
+
+def test_missing_release_section_raises(tmp_path):
+    changelog = tmp_path / "changelog.md"
+    changelog.write_text("# Changelog\n", encoding="utf-8")
+
+    try:
+        extract_release_notes.extract_release_notes(changelog, "1.2.3")
+    except ValueError as exc:
+        assert "Could not find" in str(exc)
+    else:
+        raise AssertionError("missing release section should fail")
+
+
+def test_empty_release_section_raises(tmp_path):
+    changelog = tmp_path / "changelog.md"
+    changelog.write_text(
+        """# Changelog
+
+## [1.2.3] - 2026-05-05
+
+## [1.2.2] - 2026-05-01
+""",
+        encoding="utf-8",
+    )
+
+    try:
+        extract_release_notes.extract_release_notes(changelog, "1.2.3")
+    except ValueError as exc:
+        assert "empty" in str(exc)
+    else:
+        raise AssertionError("empty release section should fail")


### PR DESCRIPTION
## Description

Tightens dependency security posture after Scorecard/OSV reported vulnerable dependency ranges.

Changes:
- raises runtime `cryptography` to `>=46.0.6`
- raises docs `pymdown-extensions` to `>=10.16.1`
- raises docs `pygments` to `>=2.20.0`
- adds a runtime dependency license audit to PR security checks and the scheduled security workflow
- uploads the license report from the full security workflow
- expands the changelog into the `0.6.7` patch release notes from `v0.6.6` through this PR
- extracts that changelog section into the automated GitHub Release notes

## Type of Change

Select exactly one option. These stable tokens are parsed by CI and release automation.

- [x] bug - Bug fix; creates a patch release.
- [ ] feature - New feature; creates a minor release.
- [ ] breaking - Breaking change; creates a major release.
- [ ] docs - Documentation-only change; no release.
- [ ] refactor - Non-functional cleanup or refactor; no release.
- [ ] test - Test-only change; no release.

## How Has This Been Tested?

- [x] **Unit Tests**: `pytest tests/scripts/test_check_dependency_licenses.py tests/scripts/test_release_helpers.py`
- [ ] **Integration Tests**: `pytest -m integration`
- [x] **Manual Test**: `ruff check`, `ruff format --check`, `py_compile`, runtime requirement export, changelog gate, and local Scorecard Vulnerabilities check

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
