### PR TITLE
fix(release): support beta release intents

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,8 +9,9 @@ Fixes # (issue)
 Select exactly one option. These stable tokens are parsed by CI and release automation.
 
 - [ ] bug - Bug fix; creates a patch release.
-- [ ] feature - New feature; creates a minor release.
-- [ ] breaking - Breaking change; creates a major release.
+- [ ] feature - Feature or stabilization work intended for the current beta minor line; creates a patch release before 1.0.
+- [ ] feature-minor - Real feature intended to advance the beta minor line; creates a minor release before 1.0.
+- [ ] breaking - Breaking beta change; creates a minor release before 1.0.
 - [ ] docs - Documentation-only change; no release.
 - [ ] refactor - Non-functional cleanup or refactor; no release.
 - [ ] test - Test-only change; no release.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 *   **NIST Curve Key Derivation**: Fixed a critical bug in `KeyExchange` where the incorrect hash algorithm (SHA-256) was being used for NIST P-384 and P-521 curves, causing authentication failures.
+*   **Beta Release Planning**: Updated release metadata parsing so `feature` PRs remain patch releases during beta stabilization, `feature-minor` explicitly advances the beta minor line, and breaking beta changes map to minor releases until the stable `1.0.0` policy is enabled.
+*   **Release PR Detection**: Added retry and merge-message fallback behavior for push-triggered release planning so GitHub API association lag does not skip a release immediately after merge.
 *   **Type Safety & Linting**: Resolved over 35 type errors and linting issues identified by `mypy` and `ruff`, particularly around `bytes`/`bytearray` buffer handling.
 *   **Regression Repairs**: Fixed `KeyExchange` unit tests by implementing backward-compatibility aliases and normalizing error messages.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -142,8 +142,9 @@ reserved for emergency recovery by repository administrators.
    In the PR body, select one `Type of Change`:
 
    - `bug`: patch release after merge
-   - `feature`: minor release after merge
-   - `breaking`: major release after merge
+   - `feature`: feature or stabilization work for the current beta minor line; patch release before `1.0.0`
+   - `feature-minor`: intentional beta minor-line feature; minor release before `1.0.0`
+   - `breaking`: breaking beta change; minor release before `1.0.0`
    - `docs`: no release
    - `refactor`: no release
    - `test`: no release

--- a/meta/CONTRIBUTING.md
+++ b/meta/CONTRIBUTING.md
@@ -142,8 +142,9 @@ reserved for emergency recovery by repository administrators.
    In the PR body, select one `Type of Change`:
 
    - `bug`: patch release after merge
-   - `feature`: minor release after merge
-   - `breaking`: major release after merge
+   - `feature`: feature or stabilization work for the current beta minor line; patch release before `1.0.0`
+   - `feature-minor`: intentional beta minor-line feature; minor release before `1.0.0`
+   - `breaking`: breaking beta change; minor release before `1.0.0`
    - `docs`: no release
    - `refactor`: no release
    - `test`: no release

--- a/meta/internal/lifecycle/01-overview-and-stage-gates.md
+++ b/meta/internal/lifecycle/01-overview-and-stage-gates.md
@@ -101,12 +101,18 @@ Release mapping:
 
 | PR type | Release |
 | --- | --- |
-| `breaking` | Major |
-| `feature` | Minor |
+| `breaking` | Minor before `1.0.0`; major only after stable policy is enabled |
+| `feature-minor` | Minor before `1.0.0` |
+| `feature` | Patch before `1.0.0` |
 | `bug` | Patch |
 | `docs` | No release |
 | `refactor` | No release |
 | `test` | No release |
+
+Before `1.0.0`, the beta line uses `feature` for stabilization features that
+should remain in the current beta minor line. Use `feature-minor` only when the
+PR intentionally advances the beta minor line. After `1.0.0`, the release
+mapping should be revised to strict semantic versioning.
 
 ## Version Source Of Truth
 

--- a/meta/internal/lifecycle/02-before-v1-lifecycle-epics.md
+++ b/meta/internal/lifecycle/02-before-v1-lifecycle-epics.md
@@ -66,6 +66,7 @@ Implementation tasks:
 
   - [ ] bug
   - [ ] feature
+  - [ ] feature-minor
   - [ ] breaking
   - [ ] docs
   - [ ] refactor
@@ -77,7 +78,7 @@ Implementation tasks:
 - Fail validation if zero type boxes are selected.
 - Fail validation if more than one type box is selected.
 - Fail validation if description is empty or still placeholder-only.
-- For `bug`, `feature`, and `breaking`, require test evidence.
+- For `bug`, `feature`, `feature-minor`, and `breaking`, require test evidence.
 - Output parsed values:
   - `change_type`
   - `release_needed`

--- a/meta/internal/lifecycle/03-before-v1-release-process-epics.md
+++ b/meta/internal/lifecycle/03-before-v1-release-process-epics.md
@@ -40,8 +40,9 @@ Acceptance criteria:
 
 - A docs-only merged PR exits with no release.
 - A bug PR plans a patch release.
-- A feature PR plans a minor release.
-- A breaking PR plans a major release.
+- A feature PR plans a patch release during beta stabilization.
+- A feature-minor PR plans a minor release during beta stabilization.
+- A breaking PR plans a minor release during beta stabilization.
 - A `[skip release]` release-bump commit does not trigger a second release.
 
 Dependencies:

--- a/meta/internal/lifecycle/09-implementation-roadmap.md
+++ b/meta/internal/lifecycle/09-implementation-roadmap.md
@@ -128,8 +128,9 @@ Tasks:
 Done when:
 
 - Bug PR creates patch release.
-- Feature PR creates minor release.
-- Breaking PR creates major release.
+- Feature PR creates patch release during beta stabilization.
+- Feature-minor PR creates minor release during beta stabilization.
+- Breaking PR creates minor release during beta stabilization.
 - Docs/refactor/test PRs do not release.
 - Rerun does not duplicate tag/release.
 

--- a/scripts/check_changelog_updated.py
+++ b/scripts/check_changelog_updated.py
@@ -89,8 +89,8 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     print(
-        f"{args.changelog.as_posix()} must be updated for bug, feature, "
-        "and breaking-change PRs.",
+        f"{args.changelog.as_posix()} must be updated for release-impacting "
+        "PRs: bug, feature, feature-minor, and breaking.",
         file=sys.stderr,
     )
     return 1

--- a/scripts/plan_release.py
+++ b/scripts/plan_release.py
@@ -6,7 +6,9 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sys
+import time
 import urllib.error
 import urllib.request
 from dataclasses import dataclass
@@ -70,37 +72,78 @@ def _github_api_json(path: str, token: str) -> Any:
         raise RuntimeError(f"GitHub API request failed: {exc.code} {body}") from exc
 
 
-def _associated_pull_requests(repository: str, sha: str, token: str) -> list[dict[str, Any]]:
+def _associated_pull_requests(
+    repository: str, sha: str, token: str
+) -> list[dict[str, Any]]:
     data = _github_api_json(f"/repos/{repository}/commits/{sha}/pulls", token)
     if not isinstance(data, list):
         raise RuntimeError("GitHub API returned an unexpected pull request payload.")
     return [item for item in data if isinstance(item, dict)]
 
 
-def _last_merged_pull_request(
-    repository: str, sha: str, token: str
+def _pull_request_by_number(
+    repository: str, number: int, token: str
 ) -> dict[str, Any] | None:
-    candidates = [
-        pr
-        for pr in _associated_pull_requests(repository, sha, token)
-        if pr.get("merged_at")
-    ]
-    if not candidates:
+    data = _github_api_json(f"/repos/{repository}/pulls/{number}", token)
+    return data if isinstance(data, dict) else None
+
+
+def _last_merged_pull_request(
+    repository: str, sha: str, token: str, *, attempts: int = 6, delay: float = 5.0
+) -> dict[str, Any] | None:
+    for attempt in range(1, attempts + 1):
+        candidates = [
+            pr
+            for pr in _associated_pull_requests(repository, sha, token)
+            if pr.get("merged_at")
+        ]
+        if candidates:
+            return sorted(
+                candidates,
+                key=lambda pr: (str(pr.get("merged_at")), int(pr.get("number") or 0)),
+            )[-1]
+        if attempt < attempts:
+            time.sleep(delay)
+    return None
+
+
+def _merge_message_pr_number(message: str) -> int | None:
+    first_line = message.splitlines()[0] if message else ""
+    match = re.search(r"\(#(?P<number>\d+)\)\s*$", first_line)
+    return int(match.group("number")) if match else None
+
+
+def _fallback_merged_pull_request_from_message(
+    *, repository: str, message: str, sha: str, token: str
+) -> dict[str, Any] | None:
+    number = _merge_message_pr_number(message)
+    if number is None:
         return None
-    return sorted(
-        candidates,
-        key=lambda pr: (str(pr.get("merged_at")), int(pr.get("number") or 0)),
-    )[-1]
+    pr = _pull_request_by_number(repository, number, token)
+    if not pr or not pr.get("merged_at"):
+        return None
+    if str(pr.get("merge_commit_sha") or "") != sha:
+        return None
+    return pr
 
 
 def _plan_from_release_type(
-    *, release_type: str, current_version: str, dry_run: bool, source_sha: str, reason: str
+    *,
+    release_type: str,
+    current_version: str,
+    dry_run: bool,
+    source_sha: str,
+    reason: str,
 ) -> ReleasePlan:
     if release_type not in DIRECT_RELEASE_TYPES:
         raise ValueError(f"Unsupported release type override: {release_type!r}")
 
     release_needed = release_type in RELEASE_BUMPS
-    next_version = bump_version(current_version, release_type) if release_needed else current_version
+    next_version = (
+        bump_version(current_version, release_type)
+        if release_needed
+        else current_version
+    )
     return ReleasePlan(
         release_needed=str(release_needed).lower(),
         release_type=release_type if release_needed else "none",
@@ -163,7 +206,9 @@ def create_plan(event_path: Path) -> ReleasePlan:
     current_version = read_pyproject_version()
 
     if event_name == "workflow_dispatch":
-        inputs = payload.get("inputs") if isinstance(payload.get("inputs"), dict) else {}
+        inputs = (
+            payload.get("inputs") if isinstance(payload.get("inputs"), dict) else {}
+        )
         release_type = str(inputs.get("release_type") or "patch")
         dry_run = str(inputs.get("dry_run", "true")).lower() != "false"
         if not dry_run:
@@ -179,7 +224,9 @@ def create_plan(event_path: Path) -> ReleasePlan:
     if event_name == "pull_request":
         pr = payload.get("pull_request")
         if not isinstance(pr, dict):
-            raise ValueError("pull_request event does not include a pull_request object.")
+            raise ValueError(
+                "pull_request event does not include a pull_request object."
+            )
         return _plan_from_pr_body(
             body=str(pr.get("body") or ""),
             current_version=current_version,
@@ -206,9 +253,18 @@ def create_plan(event_path: Path) -> ReleasePlan:
         repository = os.environ.get("GITHUB_REPOSITORY", "")
         token = os.environ.get("GITHUB_TOKEN", "")
         if not repository or not token or not source_sha:
-            raise ValueError("GITHUB_REPOSITORY, GITHUB_TOKEN, and GITHUB_SHA are required.")
+            raise ValueError(
+                "GITHUB_REPOSITORY, GITHUB_TOKEN, and GITHUB_SHA are required."
+            )
 
         pr = _last_merged_pull_request(repository, source_sha, token)
+        if pr is None:
+            pr = _fallback_merged_pull_request_from_message(
+                repository=repository,
+                message=message,
+                sha=source_sha,
+                token=token,
+            )
         if pr is None:
             return _plan_from_release_type(
                 release_type="none",

--- a/scripts/validate_pr_body.py
+++ b/scripts/validate_pr_body.py
@@ -11,11 +11,20 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
-VALID_TYPES = ("bug", "feature", "breaking", "docs", "refactor", "test")
+VALID_TYPES = (
+    "bug",
+    "feature",
+    "feature-minor",
+    "breaking",
+    "docs",
+    "refactor",
+    "test",
+)
 RELEASE_TYPES = {
     "bug": ("true", "patch"),
-    "feature": ("true", "minor"),
-    "breaking": ("true", "major"),
+    "feature": ("true", "patch"),
+    "feature-minor": ("true", "minor"),
+    "breaking": ("true", "minor"),
     "docs": ("false", "none"),
     "refactor": ("false", "none"),
     "test": ("false", "none"),
@@ -117,7 +126,12 @@ def validate_body(body: str) -> ValidationResult:
             "PR description is empty or still contains only placeholder text."
         )
 
-    if change_type in {"bug", "feature", "breaking"} and not _has_test_evidence(body):
+    if change_type in {
+        "bug",
+        "feature",
+        "feature-minor",
+        "breaking",
+    } and not _has_test_evidence(body):
         errors.append(
             f"Type '{change_type}' requires test evidence in "
             "'How Has This Been Tested?'."

--- a/tests/scripts/test_release_helpers.py
+++ b/tests/scripts/test_release_helpers.py
@@ -49,7 +49,7 @@ def test_bump_version_by_release_type():
     assert plan_release.bump_version("1.2.3", "major") == "2.0.0"
 
 
-def test_pull_request_feature_plans_minor_release(monkeypatch, tmp_path):
+def test_pull_request_feature_plans_patch_release_during_beta(monkeypatch, tmp_path):
     monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
     monkeypatch.setenv("GITHUB_SHA", "abc123")
     event_path = write_event(
@@ -66,11 +66,57 @@ def test_pull_request_feature_plans_minor_release(monkeypatch, tmp_path):
     plan = plan_release.create_plan(event_path)
 
     assert plan.release_needed == "true"
-    assert plan.release_type == "minor"
+    assert plan.release_type == "patch"
     assert plan.dry_run == "true"
-    assert plan.next_version == plan_release.bump_version(plan.current_version, "minor")
+    assert plan.next_version == plan_release.bump_version(plan.current_version, "patch")
     assert plan.tag == f"v{plan.next_version}"
     assert plan.source_pr == "130"
+
+
+def test_pull_request_feature_minor_plans_minor_release_during_beta(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+    monkeypatch.setenv("GITHUB_SHA", "abc123")
+    event_path = write_event(
+        tmp_path,
+        {
+            "pull_request": {
+                "number": 132,
+                "html_url": "https://github.com/stratza/spindlex/pull/132",
+                "body": pr_body("feature-minor"),
+            }
+        },
+    )
+
+    plan = plan_release.create_plan(event_path)
+
+    assert plan.release_needed == "true"
+    assert plan.release_type == "minor"
+    assert plan.change_type == "feature-minor"
+    assert plan.next_version == plan_release.bump_version(plan.current_version, "minor")
+
+
+def test_pull_request_breaking_plans_minor_release_during_beta(monkeypatch, tmp_path):
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+    monkeypatch.setenv("GITHUB_SHA", "abc123")
+    event_path = write_event(
+        tmp_path,
+        {
+            "pull_request": {
+                "number": 133,
+                "html_url": "https://github.com/stratza/spindlex/pull/133",
+                "body": pr_body("breaking"),
+            }
+        },
+    )
+
+    plan = plan_release.create_plan(event_path)
+
+    assert plan.release_needed == "true"
+    assert plan.release_type == "minor"
+    assert plan.change_type == "breaking"
+    assert plan.next_version == plan_release.bump_version(plan.current_version, "minor")
 
 
 def test_pull_request_docs_plans_no_release(monkeypatch, tmp_path):
@@ -133,6 +179,62 @@ def test_push_skip_release_commit_plans_no_release(monkeypatch, tmp_path):
 
     assert plan.release_needed == "false"
     assert plan.reason == "head commit contains [skip release]"
+
+
+def test_push_falls_back_to_merge_commit_pr_number(monkeypatch, tmp_path):
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "push")
+    monkeypatch.setenv("GITHUB_SHA", "merge-sha")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "stratza/spindlex")
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+    monkeypatch.setattr(plan_release, "_last_merged_pull_request", lambda *a, **k: None)
+    monkeypatch.setattr(
+        plan_release,
+        "_pull_request_by_number",
+        lambda *a, **k: {
+            "number": 170,
+            "html_url": "https://github.com/stratza/spindlex/pull/170",
+            "merged_at": "2026-05-09T06:57:47Z",
+            "merge_commit_sha": "merge-sha",
+            "body": pr_body("feature"),
+        },
+    )
+    event_path = write_event(
+        tmp_path,
+        {"head_commit": {"message": "v0.6.10: Stabilization work (#170)"}},
+    )
+
+    plan = plan_release.create_plan(event_path)
+
+    assert plan.release_needed == "true"
+    assert plan.release_type == "patch"
+    assert plan.source_pr == "170"
+
+
+def test_push_fallback_rejects_wrong_merge_commit_sha(monkeypatch, tmp_path):
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "push")
+    monkeypatch.setenv("GITHUB_SHA", "merge-sha")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "stratza/spindlex")
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+    monkeypatch.setattr(plan_release, "_last_merged_pull_request", lambda *a, **k: None)
+    monkeypatch.setattr(
+        plan_release,
+        "_pull_request_by_number",
+        lambda *a, **k: {
+            "number": 170,
+            "merged_at": "2026-05-09T06:57:47Z",
+            "merge_commit_sha": "different-sha",
+            "body": pr_body("feature"),
+        },
+    )
+    event_path = write_event(
+        tmp_path,
+        {"head_commit": {"message": "v0.6.10: Stabilization work (#170)"}},
+    )
+
+    plan = plan_release.create_plan(event_path)
+
+    assert plan.release_needed == "false"
+    assert plan.reason == "no merged PR associated with push SHA"
 
 
 def test_render_version_file_matches_expected_shape():

--- a/tests/scripts/test_validate_pr_body.py
+++ b/tests/scripts/test_validate_pr_body.py
@@ -52,7 +52,19 @@ def test_feature_change_requires_test_evidence():
     assert "requires test evidence" in result.errors[0]
 
 
-def test_feature_change_maps_to_minor_release():
+def test_feature_minor_change_requires_test_evidence():
+    result = validate_pr_body.validate_body(
+        pr_body(
+            type_lines="- [x] feature-minor - Adds behavior",
+            tested="- [ ] Unit Tests: `pytest tests/test_...`",
+        )
+    )
+
+    assert not result.valid
+    assert "requires test evidence" in result.errors[0]
+
+
+def test_feature_change_maps_to_patch_release_during_beta():
     result = validate_pr_body.validate_body(
         pr_body(
             type_lines="- [x] feature - Adds behavior",
@@ -62,6 +74,34 @@ def test_feature_change_maps_to_minor_release():
 
     assert result.valid
     assert result.change_type == "feature"
+    assert result.release_needed == "true"
+    assert result.release_type == "patch"
+
+
+def test_feature_minor_change_maps_to_minor_release_during_beta():
+    result = validate_pr_body.validate_body(
+        pr_body(
+            type_lines="- [x] feature-minor - Intentional beta minor feature",
+            tested="- [x] Unit Tests: `pytest tests/unit`",
+        )
+    )
+
+    assert result.valid
+    assert result.change_type == "feature-minor"
+    assert result.release_needed == "true"
+    assert result.release_type == "minor"
+
+
+def test_breaking_change_maps_to_minor_release_during_beta():
+    result = validate_pr_body.validate_body(
+        pr_body(
+            type_lines="- [x] breaking - Breaking beta change",
+            tested="- [x] Unit Tests: `pytest tests/unit`",
+        )
+    )
+
+    assert result.valid
+    assert result.change_type == "breaking"
     assert result.release_needed == "true"
     assert result.release_type == "minor"
 


### PR DESCRIPTION
## Description

Fix the beta release intent mechanism so stabilization feature PRs can remain in the current beta patch line while intentional beta minor releases use an explicit token.

Key changes:
- Map `feature` PRs to patch releases during beta stabilization.
- Add `feature-minor` for intentional beta minor releases.
- Map `breaking` beta changes to minor releases until the stable 1.0 policy is enabled.
- Update the PR template, contributor docs, and lifecycle docs to describe the beta release contract.
- Harden push-triggered release planning against GitHub commit/PR association lag with retries and a merge-message fallback.
- Verify PR #170's existing `feature` body now maps to a patch release.

Fixes the release-planning behavior that caused PR #170 to skip the intended `0.6.10` publish.

## Type of Change

- [x] bug - Bug fix; creates a patch release.

## How Has This Been Tested?

- [x] **Unit Tests**: `.venv/bin/python -m pytest tests/scripts/test_validate_pr_body.py tests/scripts/test_release_helpers.py tests/scripts/test_check_changelog_updated.py`
- [x] **Lint**: `.venv/bin/ruff check scripts/validate_pr_body.py scripts/plan_release.py scripts/check_changelog_updated.py tests/scripts/test_validate_pr_body.py tests/scripts/test_release_helpers.py tests/scripts/test_check_changelog_updated.py`
- [x] **Format Check**: `.venv/bin/ruff format --check scripts/validate_pr_body.py scripts/plan_release.py scripts/check_changelog_updated.py tests/scripts/test_validate_pr_body.py tests/scripts/test_release_helpers.py tests/scripts/test_check_changelog_updated.py`
- [x] **Manual Test**: Validated PR #170 body maps to `change_type=feature`, `release_type=patch` under the updated parser.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
