### PR TITLE
Fix partial release publish recovery

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,11 @@ on:
           - minor
           - major
           - none
+      recover_published_version:
+        description: "Complete tag and GitHub Release for a version already published to PyPI."
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -99,6 +104,10 @@ jobs:
       - main-security
     if: >
       always() &&
+      (
+        github.event_name != 'workflow_dispatch' ||
+        inputs.recover_published_version == ''
+      ) &&
       needs.plan.outputs.release_needed == 'true' &&
       (
         github.event_name != 'push' ||
@@ -194,6 +203,112 @@ jobs:
             dist-integrity/*
           if-no-files-found: error
 
+  recover-published-release:
+    name: Recover published release
+    if: github.event_name == 'workflow_dispatch' && inputs.recover_published_version != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - id: release-token
+        name: Create release app token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          token: ${{ steps.release-token.outputs.token }}
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.11"
+      - name: Install build tooling
+        run: uv pip install --system build twine
+      - id: recovery
+        name: Validate recovery target
+        env:
+          RECOVERY_VERSION: ${{ inputs.recover_published_version }}
+        run: |
+          version="${RECOVERY_VERSION#v}"
+          tag="v$version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+          python scripts/sync_project_version.py --check
+          python - <<'PY'
+          import os
+          import tomllib
+
+          version = os.environ["RECOVERY_VERSION"].removeprefix("v")
+          with open("pyproject.toml", "rb") as pyproject:
+              current = tomllib.load(pyproject)["project"]["version"]
+          if current != version:
+              raise SystemExit(
+                  f"Recovery version {version!r} does not match pyproject.toml {current!r}."
+              )
+          PY
+          python scripts/extract_release_notes.py --version "$version" --output release-notes.md
+      - name: Verify PyPI version already exists
+        env:
+          VERSION: ${{ steps.recovery.outputs.version }}
+        run: |
+          python - <<'PY'
+          import os
+          import urllib.error
+          import urllib.request
+
+          version = os.environ["VERSION"]
+          url = f"https://pypi.org/pypi/spindlex/{version}/json"
+          try:
+              with urllib.request.urlopen(url, timeout=30):
+                  print(f"PyPI version {version} exists.")
+          except urllib.error.HTTPError as exc:
+              if exc.code == 404:
+                  raise SystemExit(f"PyPI version {version} does not exist.")
+              raise
+          PY
+      - name: Build and validate recovery artifacts
+        run: |
+          python -m build
+          python -m twine check dist/*
+          python scripts/generate_release_integrity.py --dist dist --output-dir dist-integrity
+      - id: release
+        name: Create missing tag and GitHub Release
+        env:
+          GH_TOKEN: ${{ steps.release-token.outputs.token }}
+          TAG: ${{ steps.recovery.outputs.tag }}
+        run: |
+          {
+            echo ""
+            echo "---"
+            echo ""
+            echo "Recovery run for package artifacts already published to PyPI."
+            echo ""
+            echo "**Full Changelog:** https://github.com/${{ github.repository }}/blob/main/docs/changelog.md"
+          } >> release-notes.md
+
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "::notice::Tag $TAG already exists; continuing to GitHub Release check."
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git tag -a "$TAG" -m "Release $TAG"
+            git push origin "$TAG"
+          fi
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "::notice::GitHub Release $TAG already exists."
+            exit 0
+          fi
+
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --notes-file release-notes.md \
+            dist/* \
+            dist-integrity/*
+
   create-release-pr:
     name: Create release-version PR
     needs:
@@ -259,13 +374,24 @@ jobs:
             exit 0
           fi
 
-          if [ "$branch_exists" = "false" ]; then
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if [ "$branch_exists" = "true" ]; then
+            git fetch origin "$branch"
+            git checkout -B "$branch" "origin/$branch"
+            python scripts/sync_project_version.py --check
+          else
             git checkout -b "$branch"
             python scripts/sync_project_version.py --version "$NEXT_VERSION"
             python scripts/sync_project_version.py --check
-            git add pyproject.toml spindlex/_version.py
+          fi
+
+          python scripts/finalize_changelog_release.py --version "$NEXT_VERSION"
+          git add docs/changelog.md pyproject.toml spindlex/_version.py
+          if git diff --cached --quiet; then
+            echo "::notice::Release branch $branch already has current release metadata."
+          else
             git commit \
               -m "chore(release): $TAG [publish release]" \
               -m "Source PR: #$SOURCE_PR $SOURCE_PR_URL"
@@ -348,17 +474,8 @@ jobs:
         run: uv pip install --system build twine
       - id: prepare
         name: Validate release commit
-        env:
-          TAG: ${{ needs.plan.outputs.tag }}
         run: |
-          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
-            echo "publish_needed=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Tag $TAG already exists; skipping duplicate release."
-            exit 0
-          fi
-
           python scripts/sync_project_version.py --check
-
           echo "publish_needed=true" >> "$GITHUB_OUTPUT"
       - name: Build and validate distributions
         if: steps.prepare.outputs.publish_needed == 'true'
@@ -425,9 +542,6 @@ jobs:
           SOURCE_PR_URL: ${{ needs.plan.outputs.source_pr_url }}
           RELEASE_TYPE: ${{ needs.plan.outputs.release_type }}
         run: |
-          git tag -a "$TAG" -m "Release $TAG"
-          git push origin "$TAG"
-
           python scripts/extract_release_notes.py \
             --version "${{ needs.plan.outputs.next_version }}" \
             --output release-notes.md
@@ -441,6 +555,21 @@ jobs:
             echo ""
             echo "**Full Changelog:** https://github.com/${{ github.repository }}/blob/main/docs/changelog.md"
           } >> release-notes.md
+
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "::notice::Tag $TAG already exists; continuing to GitHub Release check."
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git tag -a "$TAG" -m "Release $TAG"
+            git push origin "$TAG"
+          fi
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "::notice::GitHub Release $TAG already exists."
+            echo "release_complete=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           gh release create "$TAG" \
             --title "$TAG" \

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,10 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+*   Made the protected publish job idempotent after partial PyPI uploads, added a manual recovery mode for already-published versions, configured Git identity before annotated tag creation, and finalized changelog sections for both new and recovered release-version PR branches before release-note extraction.
+
+## [0.7.1] - 2026-05-29
+
 ### Summary
 This maintainer-facing readiness entry documents the repository lifecycle work
-that is pending release assignment. It does not represent a published package
-version by itself.
+released in 0.7.1.
 
 ### Added
 *   Public project policy docs for production usage, compatibility, API stability, release policy, governance, dependency handling, repository settings, CI policy, release operations, release verification, vulnerability response, architecture/security boundaries, logging operations, and public roadmap tracking.

--- a/scripts/finalize_changelog_release.py
+++ b/scripts/finalize_changelog_release.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Move the current changelog notes from Unreleased into a release section."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import re
+import sys
+from pathlib import Path
+
+DEFAULT_CHANGELOG = Path("docs/changelog.md")
+UNRELEASED_HEADING = "## [Unreleased]"
+RELEASE_HEADING = re.compile(r"^## \[(?P<version>[^\]]+)\](?:\s+-\s+.*)?$")
+
+
+def finalize_changelog(content: str, *, version: str, release_date: str) -> str:
+    lines = content.splitlines()
+    if any(
+        (match := RELEASE_HEADING.match(line)) and match.group("version") == version
+        for line in lines
+    ):
+        return content if content.endswith("\n") else f"{content}\n"
+
+    try:
+        unreleased_index = lines.index(UNRELEASED_HEADING)
+    except ValueError as exc:
+        raise ValueError("Could not find ## [Unreleased] in changelog.") from exc
+
+    insert_at = unreleased_index + 1
+    release_heading = f"## [{version}] - {release_date}"
+    lines[insert_at:insert_at] = ["", release_heading]
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--changelog", type=Path, default=DEFAULT_CHANGELOG)
+    parser.add_argument("--version", required=True)
+    parser.add_argument(
+        "--date",
+        default=dt.datetime.now(dt.UTC).date().isoformat(),
+        help="Release date to write in YYYY-MM-DD format.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        updated = finalize_changelog(
+            args.changelog.read_text(encoding="utf-8"),
+            version=args.version,
+            release_date=args.date,
+        )
+    except Exception as exc:
+        print(f"Changelog finalization failed: {exc}", file=sys.stderr)
+        return 1
+
+    args.changelog.write_text(updated, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_finalize_changelog_release.py
+++ b/tests/scripts/test_finalize_changelog_release.py
@@ -1,0 +1,67 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parents[2] / "scripts"
+
+
+def load_script(name: str):
+    path = SCRIPT_DIR / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+finalize_changelog_release = load_script("finalize_changelog_release")
+
+
+def test_finalize_changelog_moves_unreleased_notes_under_version():
+    content = """# Changelog
+
+## [Unreleased]
+
+### Fixed
+*   Important fix.
+
+## [0.7.0] - 2026-05-16
+"""
+
+    updated = finalize_changelog_release.finalize_changelog(
+        content, version="0.7.1", release_date="2026-05-29"
+    )
+
+    assert "## [Unreleased]\n\n## [0.7.1] - 2026-05-29\n\n### Fixed" in updated
+    assert updated.endswith("\n")
+
+
+def test_finalize_changelog_is_idempotent_for_existing_version():
+    content = """# Changelog
+
+## [Unreleased]
+
+## [0.7.1] - 2026-05-29
+
+### Fixed
+*   Important fix.
+"""
+
+    updated = finalize_changelog_release.finalize_changelog(
+        content, version="0.7.1", release_date="2026-05-30"
+    )
+
+    assert updated == content
+
+
+def test_finalize_changelog_requires_unreleased_heading():
+    try:
+        finalize_changelog_release.finalize_changelog(
+            "# Changelog\n", version="0.7.1", release_date="2026-05-29"
+        )
+    except ValueError as exc:
+        assert "Unreleased" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError")


### PR DESCRIPTION
## Description

Fixes the partial publish from Release #84 after the protected v0.7.1 release PR merged.

The package artifacts for `spindlex==0.7.1` were already published to PyPI and verified, but the workflow failed before creating the annotated Git tag and GitHub Release because Git identity was not configured in the publish job.

This PR:

- configures Git identity before annotated tag creation;
- makes tag/GitHub Release creation idempotent when PyPI already has the version;
- adds a manual `recover_published_version` workflow-dispatch path to complete tag and GitHub Release creation for an already-published version without republishing PyPI;
- finalizes changelog sections in generated release-version PRs so release-note extraction has a real `## [X.Y.Z]` heading;
- moves the already-published 0.7.1 changelog notes under `## [0.7.1] - 2026-05-29` while leaving this fix under `Unreleased`.

Issue follow-up:

- #182 is resolved by the merged v0.7.1 release PR path.
- #185 is the active partial-publish issue; after this PR is merged, run the Release workflow manually with `recover_published_version` set to `0.7.1`.

## Type of Change

- [ ] bug - Bug fix; creates a patch release.
- [ ] feature - Feature or stabilization work intended for the current beta minor line; creates a patch release before 1.0.
- [ ] feature-minor - Real feature intended to advance the beta minor line; creates a minor release before 1.0.
- [ ] breaking - Breaking beta change; creates a minor release before 1.0.
- [ ] docs - Documentation-only change; no release.
- [x] refactor - Non-functional cleanup or refactor; no release.
- [ ] test - Test-only change; no release.

## How Has This Been Tested?

- [x] `docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:1.7.7 -color`
- [x] `git diff --check`
- [x] `.venv/bin/python -m pytest tests/scripts/test_finalize_changelog_release.py tests/scripts/test_extract_release_notes.py tests/scripts/test_release_helpers.py -q`
- [x] `.venv/bin/python scripts/extract_release_notes.py --version 0.7.1 --output /tmp/spindlex-0.7.1-notes.md`
- [x] `.venv/bin/python -m mkdocs build --strict`
