### PR TITLE
fix: pre-v1 security and correctness hardening (dev-0.7.2)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,28 @@ This maintainer-facing readiness entry documents the repository lifecycle work
 that is pending release assignment. It does not represent a published package
 version by itself.
 
+## [0.7.2] - Unreleased
+
+### Changed
+*   Removed SHA-1 from `CryptographyBackend.HASH_ALGORITHMS` — SHA-1 now raises `CryptoException` if requested, enforcing the no-SHA-1 security invariant at the backend layer.
+*   Replaced all `default_backend()` calls (`kex.py`, `backend.py`, `pkey.py`) with the implicit default introduced in `cryptography>=36.0.0`, eliminating deprecation warnings.
+*   Moved `_AEAD_CIPHERS` frozenset to module level in `transport.py` — was being re-allocated on every `_build_packet()` call.
+*   Version-string silent fallbacks in `_compute_ecdh_exchange_hash`, `_compute_curve25519_exchange_hash`, and `_compute_exchange_hash` replaced with explicit `CryptoException` guards — a missing version string now fails loudly instead of producing a wrong exchange hash.
+*   Dead `try: … except Exception: raise` wrapper removed from `_perform_dh_group14_sha256`.
+*   `KeyExchange.generate_keys()` deprecated with `DeprecationWarning`; will be removed in v1.0.
+*   `WarningPolicy` docstring corrected to accurately describe TOFU behaviour; `AutoAddPolicy` now emits a `logger.warning` alongside the existing `UserWarning`.
+*   Hardcoded `"utf-8"` literals in `ssh_client.py` replaced with `SSH_STRING_ENCODING`.
+*   Added `[tool.isort]` and `[tool.black]` configs to `pyproject.toml` so both tools align with ruff's formatting style.
+
+### Fixed
+*   `MSG_EXT_INFO = 7` added to `protocol/constants.py`; magic literals `7` and `60` in `transport.py` replaced with named constants (`MSG_EXT_INFO`, `MSG_USERAUTH_PK_OK`).
+*   Dead KEX fallback in `KeyExchange.start_kex()` replaced with an explicit `CryptoException` — the old path would have sent a spurious second `KEXINIT` in server mode.
+*   `assert` statements in crypto and KEX paths replaced with explicit `if … raise CryptoException` guards, which survive Python's `-O` optimisation flag.
+*   `_kex_thread` and `_server_key` declared in `Transport.__init__` — previously only set via `getattr` fallbacks, causing undeclared-attribute mypy warnings.
+*   Misleading `_recv_bytes` lock-ordering comment updated to accurately describe the fast-path vs slow-path locking behaviour.
+*   `SSHClient.save_host_keys()` no longer accesses private `_filename` and `_keys` attributes of `HostKeyStorage`; new `HostKeyStorage.copy_from()` method provides the correct encapsulated API.
+*   `SSHClient.connect()` now raises `ConfigurationException` immediately for `compress=True` and `gss_kex=True` rather than silently ignoring them.
+
 ### Added
 *   Public project policy docs for production usage, compatibility, API stability, release policy, governance, dependency handling, repository settings, CI policy, release operations, release verification, vulnerability response, architecture/security boundaries, logging operations, and public roadmap tracking.
 *   Architecture Decision Records for release policy, documentation layout, supported platforms, and API stability boundaries.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -264,3 +264,14 @@ ignore = [
 # ([tool.isort]) so the two tools do not disagree about first-party
 # imports (blank line between ``import pytest`` and ``from spindlex...``).
 known-first-party = ["spindlex"]
+
+[tool.isort]
+# Mirror ruff's formatter output so standalone isort agrees with ruff format.
+profile = "black"
+line_length = 88
+known_first_party = ["spindlex"]
+src_paths = ["spindlex", "tests"]
+
+[tool.black]
+line-length = 88
+target-version = ["py39", "py310", "py311", "py312", "py313"]

--- a/spindlex/client/async_ssh_client.py
+++ b/spindlex/client/async_ssh_client.py
@@ -194,7 +194,7 @@ class AsyncSSHClient:
                     # Exponential backoff with jitter: 0.2s, 0.4s, 0.8s...
                     import random
 
-                    wait = (0.2 * (2**attempt)) + (random.random() * 0.1)  # noqa: S311 # nosec
+                    wait = (0.2 * (2**attempt)) + (random.random() * 0.1)  # noqa: S311 # nosec  # fmt: skip
                     self._logger.debug(
                         f"Connection attempt {attempt + 1} failed: {e}. Retrying in {wait:.2f}s..."
                     )

--- a/spindlex/client/ssh_client.py
+++ b/spindlex/client/ssh_client.py
@@ -22,6 +22,7 @@ from ..exceptions import (
 )
 from ..hostkeys.policy import MissingHostKeyPolicy, RejectPolicy
 from ..hostkeys.storage import HostKeyStorage
+from ..protocol.constants import SSH_STRING_ENCODING
 from ..transport.channel import Channel
 from ..transport.transport import Transport
 
@@ -104,7 +105,7 @@ class ChannelFile:
             raise ValueError("File not opened for writing")
 
         if isinstance(data, str):
-            data = data.encode("utf-8")
+            data = data.encode(SSH_STRING_ENCODING)
 
         return self._channel.send(data)
 
@@ -165,7 +166,7 @@ class ChannelFile:
             result.extend(char)
             if char == b"\n":
                 break
-        return result.decode("utf-8", errors="replace")
+        return result.decode(SSH_STRING_ENCODING, errors="replace")
 
     @property
     def channel(self) -> "Channel":
@@ -264,12 +265,10 @@ class SSHClient:
         Args:
             filename: Path to save known_hosts
         """
-        # If storage doesn't exist or filename is different, create new storage
-        if not self._host_key_storage or self._host_key_storage._filename != filename:
-            old_storage = self._host_key_storage
-            self._host_key_storage = HostKeyStorage(filename)
-            if old_storage:
-                self._host_key_storage._keys = old_storage._keys
+        if self._host_key_storage._filename != filename:
+            new_storage = HostKeyStorage(filename)
+            new_storage.copy_from(self._host_key_storage)
+            self._host_key_storage = new_storage
 
         self._host_key_storage.save()
 
@@ -326,6 +325,16 @@ class SSHClient:
         """
         if self._transport and self._transport.active:
             raise SSHException("Already connected")
+
+        if compress:
+            from ..exceptions import ConfigurationException
+
+            raise ConfigurationException("Compression is not yet supported")
+
+        if gss_kex:
+            from ..exceptions import ConfigurationException
+
+            raise ConfigurationException("GSSAPI key exchange is not yet supported")
 
         self._hostname = hostname
         self._port = port

--- a/spindlex/crypto/backend.py
+++ b/spindlex/crypto/backend.py
@@ -10,7 +10,6 @@ import struct
 from typing import Any, Protocol
 
 from cryptography.exceptions import InvalidSignature
-from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, hmac
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from cryptography.hazmat.primitives.poly1305 import Poly1305
@@ -102,9 +101,8 @@ class CryptographyBackend:
     for modern, secure cryptographic operations.
     """
 
-    # Hash algorithm mapping
+    # Hash algorithm mapping — SHA-1 intentionally excluded (weak, not negotiated)
     HASH_ALGORITHMS = {
-        "sha1": hashes.SHA1,
         "sha256": hashes.SHA256,
         "sha384": hashes.SHA384,
         "sha512": hashes.SHA512,
@@ -120,7 +118,7 @@ class CryptographyBackend:
 
     def __init__(self) -> None:
         """Initialize cryptography backend."""
-        self.backend = default_backend()
+        pass
 
     def generate_random(self, length: int) -> bytes:
         """
@@ -145,7 +143,7 @@ class CryptographyBackend:
         Hash data using specified algorithm.
 
         Args:
-            algorithm: Hash algorithm name (sha1, sha256, sha512)
+            algorithm: Hash algorithm name (sha256, sha384, sha512)
             data: Data to hash
 
         Returns:
@@ -162,7 +160,7 @@ class CryptographyBackend:
             data_bytes = bytes(data)
 
             hash_class = self.HASH_ALGORITHMS[algorithm]
-            digest = hashes.Hash(hash_class(), backend=self.backend)  # type: ignore[abstract]
+            digest = hashes.Hash(hash_class())  # type: ignore[abstract]
             digest.update(data_bytes)
             return digest.finalize()
         except CryptoException:
@@ -195,7 +193,7 @@ class CryptographyBackend:
             if algorithm in ["aes128-ctr", "aes192-ctr", "aes256-ctr"]:
                 cipher_algo = algorithms.AES(key_bytes)
                 mode = modes.CTR(iv_bytes)
-                cipher = Cipher(cipher_algo, mode, backend=self.backend)
+                cipher = Cipher(cipher_algo, mode)
                 encryptor = cipher.encryptor()
                 return bytes(encryptor.update(data_bytes) + encryptor.finalize())
             else:
@@ -228,7 +226,7 @@ class CryptographyBackend:
             if algorithm in ["aes128-ctr", "aes192-ctr", "aes256-ctr"]:
                 cipher_algo = algorithms.AES(key_bytes)
                 mode = modes.CTR(iv_bytes)
-                cipher = Cipher(cipher_algo, mode, backend=self.backend)
+                cipher = Cipher(cipher_algo, mode)
                 decryptor = cipher.decryptor()
                 return bytes(decryptor.update(data_bytes) + decryptor.finalize())
             else:
@@ -259,7 +257,7 @@ class CryptographyBackend:
             if algorithm in ["aes128-ctr", "aes192-ctr", "aes256-ctr"]:
                 cipher_algo = algorithms.AES(key_bytes)
                 mode = modes.CTR(iv_bytes)
-                return Cipher(cipher_algo, mode, backend=self.backend)
+                return Cipher(cipher_algo, mode)
             else:
                 raise CryptoException(
                     f"Streaming cipher not supported for: {algorithm}"
@@ -291,7 +289,7 @@ class CryptographyBackend:
             data_bytes = bytes(data)
 
             hash_class = self.MAC_ALGORITHMS[algorithm]
-            h = hmac.HMAC(key_bytes, hash_class(), backend=self.backend)  # type: ignore
+            h = hmac.HMAC(key_bytes, hash_class())  # type: ignore
             h.update(data_bytes)
             return bytes(h.finalize())
         except Exception as e:
@@ -360,13 +358,13 @@ class CryptographyBackend:
             )
 
             # Hash the initial data
-            digest = hashes.Hash(hash_class(), backend=self.backend)  # type: ignore[abstract]
+            digest = hashes.Hash(hash_class())  # type: ignore[abstract]
             digest.update(initial_data)
             key_material = digest.finalize()
 
             # Extend key material if needed
             while len(key_material) < key_length:
-                digest = hashes.Hash(hash_class(), backend=self.backend)  # type: ignore[abstract]
+                digest = hashes.Hash(hash_class())  # type: ignore[abstract]
                 digest.update(shared_secret_bytes + exchange_hash_bytes + key_material)
                 key_material += digest.finalize()
 

--- a/spindlex/crypto/pkey.py
+++ b/spindlex/crypto/pkey.py
@@ -11,7 +11,6 @@ import struct
 import warnings
 from typing import Any, Optional
 
-from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec, ed25519, padding, rsa
 from cryptography.hazmat.primitives.asymmetric.utils import (
@@ -326,11 +325,11 @@ class Ed25519Key(PKey):
         try:
             if b"BEGIN OPENSSH PRIVATE KEY" in key_data:
                 self._key = serialization.load_ssh_private_key(
-                    key_data, password=password, backend=default_backend()
+                    key_data, password=password
                 )
             else:
                 self._key = serialization.load_pem_private_key(
-                    key_data, password=password, backend=default_backend()
+                    key_data, password=password
                 )
 
             if not isinstance(self._key, ed25519.Ed25519PrivateKey):
@@ -566,11 +565,11 @@ class ECDSAKey(PKey):
         try:
             if b"BEGIN OPENSSH PRIVATE KEY" in key_data:
                 self._key = serialization.load_ssh_private_key(
-                    key_data, password=password, backend=default_backend()
+                    key_data, password=password
                 )
             else:
                 self._key = serialization.load_pem_private_key(
-                    key_data, password=password, backend=default_backend()
+                    key_data, password=password
                 )
             if not isinstance(self._key, ec.EllipticCurvePrivateKey):
                 raise CryptoException("Key is not ECDSA private key")
@@ -728,7 +727,7 @@ class ECDSAKey(PKey):
             curve_name = "nistp521"
 
         key = cls(curve_name=curve_name)
-        key._key = ec.generate_private_key(key.curve, backend=default_backend())
+        key._key = ec.generate_private_key(key.curve)
         return key
 
     def save_to_file(self, filename: str, password: Optional[str] = None) -> None:
@@ -841,9 +840,7 @@ class RSAKey(PKey):
             CryptoException: If key loading fails
         """
         try:
-            self._key = serialization.load_pem_private_key(
-                key_data, password=password, backend=default_backend()
-            )
+            self._key = serialization.load_pem_private_key(key_data, password=password)
             if not isinstance(self._key, rsa.RSAPrivateKey):
                 raise CryptoException("Key is not RSA private key")
         except Exception as e:
@@ -891,7 +888,7 @@ class RSAKey(PKey):
 
             # Create RSA public key
             public_numbers = rsa.RSAPublicNumbers(e, n)
-            self._key = public_numbers.public_key(backend=default_backend())
+            self._key = public_numbers.public_key()
         except Exception as e:
             raise CryptoException(f"Failed to load RSA public key: {e}") from e
 
@@ -985,9 +982,7 @@ class RSAKey(PKey):
     ) -> "RSAKey":
         """Generate a new RSA key pair."""
         key = cls()
-        key._key = rsa.generate_private_key(
-            public_exponent=65537, key_size=bits, backend=default_backend()
-        )
+        key._key = rsa.generate_private_key(public_exponent=65537, key_size=bits)
         return key
 
     def save_to_file(self, filename: str, password: Optional[str] = None) -> None:

--- a/spindlex/hostkeys/policy.py
+++ b/spindlex/hostkeys/policy.py
@@ -56,6 +56,10 @@ class AutoAddPolicy(MissingHostKeyPolicy):
         if not accept_risk:
             import warnings
 
+            self._logger.warning(
+                "AutoAddPolicy is insecure and disables MITM protection. "
+                "Pass accept_risk=True to silence this warning."
+            )
             warnings.warn(
                 "AutoAddPolicy is insecure and disables MITM protection. "
                 "In future versions, accept_risk=True will be mandatory.",
@@ -120,10 +124,12 @@ class RejectPolicy(MissingHostKeyPolicy):
 
 class WarningPolicy(MissingHostKeyPolicy):
     """
-    Log warning but accept unknown host keys.
+    Warn and persist unknown host keys (Trust On First Use).
 
-    This policy logs a warning about unknown host keys but
-    allows the connection to proceed. Use with caution.
+    Logs a warning about unknown host keys and persists them to storage
+    so subsequent connections are verified. This is TOFU behavior: the
+    first connection is trusted unconditionally, with no MITM protection
+    for that initial handshake. Use with caution in untrusted networks.
     """
 
     def __init__(self) -> None:

--- a/spindlex/hostkeys/storage.py
+++ b/spindlex/hostkeys/storage.py
@@ -247,6 +247,20 @@ class HostKeyStorage:
         """
         return self._keys.get(hostname, [])
 
+    def copy_from(self, other: "HostKeyStorage") -> None:
+        """
+        Merge all keys from another storage instance into this one.
+
+        Args:
+            other: Source storage whose keys are merged into self
+        """
+        for hostname, keys in other._keys.items():
+            if hostname not in self._keys:
+                self._keys[hostname] = []
+            for key in keys:
+                if key not in self._keys[hostname]:
+                    self._keys[hostname].append(key)
+
     def remove(self, hostname: str, key: Optional[PKey] = None) -> bool:
         """
         Remove host key(s) for hostname.

--- a/spindlex/protocol/constants.py
+++ b/spindlex/protocol/constants.py
@@ -20,6 +20,9 @@ MSG_DEBUG = 4
 MSG_SERVICE_REQUEST = 5
 MSG_SERVICE_ACCEPT = 6
 
+# Extension negotiation (RFC 8308)
+MSG_EXT_INFO = 7
+
 # Key Exchange Messages (RFC 4253)
 MSG_KEXINIT = 20
 MSG_NEWKEYS = 21
@@ -97,7 +100,7 @@ SSH_OPEN_RESOURCE_SHORTAGE = 4
 SSH_EXTENDED_DATA_STDERR = 1
 
 # Authentication Method Names
-AUTH_PASSWORD = "password"  # noqa: S105  # nosec B105 - SSH protocol method name, not a credential
+AUTH_PASSWORD = "password"  # noqa: S105  # nosec B105 - SSH protocol method name, not a credential  # fmt: skip
 AUTH_PUBLICKEY = "publickey"
 AUTH_HOSTBASED = "hostbased"
 AUTH_KEYBOARD_INTERACTIVE = "keyboard-interactive"
@@ -393,6 +396,7 @@ __all__ = [
     "MSG_CHANNEL_WINDOW_ADJUST",
     "MSG_DEBUG",
     "MSG_DISCONNECT",
+    "MSG_EXT_INFO",
     "MSG_GLOBAL_REQUEST",
     "MSG_IGNORE",
     "MSG_KEXDH_INIT",

--- a/spindlex/transport/async_channel.py
+++ b/spindlex/transport/async_channel.py
@@ -35,9 +35,9 @@ class AsyncChannel(Channel):
         self._recv_queue: asyncio.Queue[Any] = asyncio.Queue()
         self._closed_event = asyncio.Event()
 
-        # Override parent's deque buffers with bytes for async
-        self._recv_buffer: bytes = b""
-        self._stderr_buffer: bytes = b""
+        # Override parent's deque buffers with flat bytes for async I/O path
+        self._recv_buffer = b""
+        self._stderr_buffer = b""
         self._buffer_lock = threading.Lock()
 
     def _handle_close(self) -> None:

--- a/spindlex/transport/async_transport.py
+++ b/spindlex/transport/async_transport.py
@@ -154,7 +154,7 @@ class AsyncTransport(Transport):
             self._recv_kexinit()
             self._kex.start_kex()
         finally:
-            self._kex_thread = None  # type: ignore[assignment]
+            self._kex_thread = None
             # Reset progress flag
             self._kex_in_progress = False
 

--- a/spindlex/transport/channel.py
+++ b/spindlex/transport/channel.py
@@ -47,7 +47,8 @@ class Channel:
         self._local_window_size = 0
         self._local_max_packet_size = 0
 
-        # Data buffers
+        # Data buffers — declared as Any because AsyncChannel overrides these with
+        # plain bytes (flat buffer, sliceable) vs the deque[bytes] used here.
         self._recv_buffer: Any = deque()
         self._stderr_buffer: Any = deque()
 

--- a/spindlex/transport/kex.py
+++ b/spindlex/transport/kex.py
@@ -7,7 +7,6 @@ and Diffie-Hellman for secure session key establishment.
 
 from typing import Any, Optional
 
-from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import dh
 
@@ -102,10 +101,12 @@ class KeyExchange:
             CryptoException: If key exchange fails
         """
         try:
-            # Get peer KEXINIT from transport (should already be exchanged)
+            # Transport layer must complete KEXINIT exchange before calling start_kex().
             if not self._transport._peer_kexinit:
-                self._send_kexinit()
-                self._receive_kexinit()
+                raise CryptoException(
+                    "Peer KEXINIT not received — transport must exchange KEXINIT "
+                    "before invoking KeyExchange.start_kex()"
+                )
 
             peer_kexinit_blob = self._transport._peer_kexinit.pack()
             our_kexinit_blob = self._transport._client_kexinit_blob
@@ -261,78 +262,75 @@ class KeyExchange:
 
     def _perform_dh_group14_sha256(self) -> None:
         """Perform Diffie-Hellman Group 14 SHA256 key exchange."""
-        try:
-            # Generate DH parameters
-            parameters = dh.DHParameterNumbers(
-                self.DH_GROUP14_P, self.DH_GROUP14_G
-            ).parameters(default_backend())
+        # Generate DH parameters
+        parameters = dh.DHParameterNumbers(
+            self.DH_GROUP14_P, self.DH_GROUP14_G
+        ).parameters()
 
-            # Generate private key
-            self._dh_private_key = parameters.generate_private_key()
+        # Generate private key
+        self._dh_private_key = parameters.generate_private_key()
 
-            # Get public key
-            dh_public_key = self._dh_private_key.public_key()
-            public_numbers = dh_public_key.public_numbers()
+        # Get public key
+        dh_public_key = self._dh_private_key.public_key()
+        public_numbers = dh_public_key.public_numbers()
 
-            # Store public key value
-            self._dh_public_key = public_numbers.y
-            self._dh_public_key_mpint = write_mpint(public_numbers.y)
+        # Store public key value
+        self._dh_public_key = public_numbers.y
+        self._dh_public_key_mpint = write_mpint(public_numbers.y)
 
-            # Ensure the public key is positive (SSH requirement)
-            if self._dh_public_key <= 0:
-                raise CryptoException("Invalid DH public key: must be positive")
+        # Ensure the public key is positive (SSH requirement)
+        if self._dh_public_key <= 0:
+            raise CryptoException("Invalid DH public key: must be positive")
 
-            # Send KEXDH_INIT message
-            kexdh_init = Message(MSG_KEXDH_INIT)
-            assert self._dh_public_key is not None
-            kexdh_init.add_mpint(self._dh_public_key)
-            self._transport._send_message(kexdh_init)
+        # Send KEXDH_INIT message
+        kexdh_init = Message(MSG_KEXDH_INIT)
+        if self._dh_public_key is None:
+            raise CryptoException("DH public key not generated")
+        kexdh_init.add_mpint(self._dh_public_key)
+        self._transport._send_message(kexdh_init)
 
-            # Receive KEXDH_REPLY
-            reply_msg = self._transport._expect_message(MSG_KEXDH_REPLY)
+        # Receive KEXDH_REPLY
+        reply_msg = self._transport._expect_message(MSG_KEXDH_REPLY)
 
-            # Parse KEXDH_REPLY
-            offset = 0
-            server_host_key_blob, offset = read_string(reply_msg._data, offset)
+        # Parse KEXDH_REPLY
+        offset = 0
+        server_host_key_blob, offset = read_string(reply_msg._data, offset)
 
-            # Extract server's DH public key (f)
-            server_public_int, offset = read_mpint(reply_msg._data, offset)
+        # Extract server's DH public key (f)
+        server_public_int, offset = read_mpint(reply_msg._data, offset)
 
-            # Encode f as mpint for exchange hash (RFC 4253 §8)
-            server_dh_public_blob = write_mpint(server_public_int)
+        # Encode f as mpint for exchange hash (RFC 4253 §8)
+        server_dh_public_blob = write_mpint(server_public_int)
 
-            signature_blob, offset = read_string(reply_msg._data, offset)
+        signature_blob, offset = read_string(reply_msg._data, offset)
 
-            # Store host key blob for transport
-            self._transport._server_host_key_blob = server_host_key_blob
+        # Store host key blob for transport
+        self._transport._server_host_key_blob = server_host_key_blob
 
-            # Validate server's public key
-            if server_public_int <= 1 or server_public_int >= self.DH_GROUP14_P - 1:
-                raise CryptoException("Invalid server DH public key")
+        # Validate server's public key
+        if server_public_int <= 1 or server_public_int >= self.DH_GROUP14_P - 1:
+            raise CryptoException("Invalid server DH public key")
 
-            # Compute shared secret
-            server_public_numbers = dh.DHPublicNumbers(
-                server_public_int, parameters.parameter_numbers()
-            )
-            server_public_key = server_public_numbers.public_key(default_backend())
+        # Compute shared secret
+        server_public_numbers = dh.DHPublicNumbers(
+            server_public_int, parameters.parameter_numbers()
+        )
+        server_public_key = server_public_numbers.public_key()
 
-            shared_secret_int = self._dh_private_key.exchange(server_public_key)
-            self._shared_secret = write_mpint(int.from_bytes(shared_secret_int, "big"))
+        shared_secret_int = self._dh_private_key.exchange(server_public_key)
+        self._shared_secret = write_mpint(int.from_bytes(shared_secret_int, "big"))
 
-            # Compute exchange hash
-            self._compute_exchange_hash(
-                server_host_key_blob, server_dh_public_blob, signature_blob
-            )
+        # Compute exchange hash
+        self._compute_exchange_hash(
+            server_host_key_blob, server_dh_public_blob, signature_blob
+        )
 
-            # Set session ID (first exchange hash)
-            if self._session_id is None:
-                self._session_id = self._exchange_hash
+        # Set session ID (first exchange hash)
+        if self._session_id is None:
+            self._session_id = self._exchange_hash
 
-            # Verify server signature
-            self._verify_server_signature(server_host_key_blob, signature_blob)
-
-        except Exception:
-            raise
+        # Verify server signature
+        self._verify_server_signature(server_host_key_blob, signature_blob)
 
     def _verify_server_signature(
         self, server_host_key_blob: bytes, signature_blob: bytes
@@ -342,7 +340,8 @@ class KeyExchange:
 
         try:
             server_key = PKey.from_string(server_host_key_blob)
-            assert self._exchange_hash is not None
+            if self._exchange_hash is None:
+                raise CryptoException("Exchange hash not computed")
             if not server_key.verify(signature_blob, self._exchange_hash):
                 raise CryptoException("Server host key signature verification failed")
         except Exception as e:
@@ -372,7 +371,7 @@ class KeyExchange:
                 )
 
             # Generate ECDH key pair
-            self._ecdh_private_key = ec.generate_private_key(curve, default_backend())
+            self._ecdh_private_key = ec.generate_private_key(curve)
             public_key = self._ecdh_private_key.public_key()
 
             # Get public key in uncompressed format
@@ -447,12 +446,18 @@ class KeyExchange:
         hash_data = bytearray()
 
         # Client version string
-        client_version = self._transport._client_version or "SSH-2.0-SpindleX_1.0"
-        hash_data.extend(write_string(client_version))
+        if self._transport._client_version is None:
+            raise CryptoException(
+                "Client version string not set for ECDH exchange hash"
+            )
+        hash_data.extend(write_string(self._transport._client_version))
 
         # Server version string
-        server_version = self._transport._server_version or "SSH-2.0-Unknown"
-        hash_data.extend(write_string(server_version))
+        if self._transport._server_version is None:
+            raise CryptoException(
+                "Server version string not set for ECDH exchange hash"
+            )
+        hash_data.extend(write_string(self._transport._server_version))
 
         # Client KEXINIT
         if self._client_kexinit is None:
@@ -528,7 +533,9 @@ class KeyExchange:
             )
 
             # 6. Sign exchange hash
-            signature_blob = self._sign_exchange_hash(self._exchange_hash)  # type: ignore[arg-type]
+            if self._exchange_hash is None:
+                raise CryptoException("Exchange hash not computed")
+            signature_blob = self._sign_exchange_hash(self._exchange_hash)
 
             # 7. Send KEX_ECDH_REPLY
             reply_msg = Message(MSG_KEX_ECDH_REPLY)
@@ -554,7 +561,7 @@ class KeyExchange:
             # 2. Generate DH parameters and private key
             parameters = dh.DHParameterNumbers(
                 self.DH_GROUP14_P, self.DH_GROUP14_G
-            ).parameters(default_backend())
+            ).parameters()
             self._dh_private_key = parameters.generate_private_key()
 
             # 3. Get server public key (f)
@@ -567,7 +574,7 @@ class KeyExchange:
             client_public_numbers = dh.DHPublicNumbers(
                 client_public_key_int, parameters.parameter_numbers()
             )
-            client_public_key_obj = client_public_numbers.public_key(default_backend())
+            client_public_key_obj = client_public_numbers.public_key()
             shared_secret_int = self._dh_private_key.exchange(client_public_key_obj)
             self._shared_secret = write_mpint(int.from_bytes(shared_secret_int, "big"))
 
@@ -584,7 +591,9 @@ class KeyExchange:
             )
 
             # 7. Sign exchange hash
-            signature_blob = self._sign_exchange_hash(self._exchange_hash)  # type: ignore[arg-type]
+            if self._exchange_hash is None:
+                raise CryptoException("Exchange hash not computed")
+            signature_blob = self._sign_exchange_hash(self._exchange_hash)
 
             # 8. Send MSG_KEXDH_REPLY (31)
             reply_msg = Message(MSG_KEXDH_REPLY)
@@ -626,7 +635,7 @@ class KeyExchange:
             client_public_key_blob, _ = read_string(init_msg._data, 0)
 
             # 2. Generate server ECDH key pair
-            self._ecdh_private_key = ec.generate_private_key(curve, default_backend())
+            self._ecdh_private_key = ec.generate_private_key(curve)
             server_public_key = self._ecdh_private_key.public_key()
             self._ecdh_public_key_bytes = server_public_key.public_bytes(
                 encoding=serialization.Encoding.X962,
@@ -658,7 +667,8 @@ class KeyExchange:
             )
 
             # 6. Sign exchange hash
-            assert self._exchange_hash is not None
+            if self._exchange_hash is None:
+                raise CryptoException("Exchange hash not computed")
             signature_blob = self._sign_exchange_hash(self._exchange_hash)
 
             # 7. Send KEX_ECDH_REPLY
@@ -756,19 +766,29 @@ class KeyExchange:
         self, server_host_key: bytes, client_public_key: bytes, server_public_key: bytes
     ) -> None:
         """Compute the exchange hash H for Curve25519."""
+        if self._transport._client_version is None:
+            raise CryptoException(
+                "Client version string not set for Curve25519 exchange hash"
+            )
+        if self._transport._server_version is None:
+            raise CryptoException(
+                "Server version string not set for Curve25519 exchange hash"
+            )
+        if self._client_kexinit is None:
+            raise CryptoException("Missing client KEXINIT for Curve25519 exchange hash")
+        if self._server_kexinit is None:
+            raise CryptoException("Missing server KEXINIT for Curve25519 exchange hash")
+        if self._shared_secret is None:
+            raise CryptoException("Missing shared secret for Curve25519 exchange hash")
         hash_data = bytearray()
-        hash_data.extend(
-            write_string(self._transport._client_version or "SSH-2.0-SpindleX_1.0")
-        )
-        hash_data.extend(
-            write_string(self._transport._server_version or "SSH-2.0-Unknown")
-        )
-        hash_data.extend(write_string(self._client_kexinit))  # type: ignore[arg-type]
-        hash_data.extend(write_string(self._server_kexinit))  # type: ignore[arg-type]
+        hash_data.extend(write_string(self._transport._client_version))
+        hash_data.extend(write_string(self._transport._server_version))
+        hash_data.extend(write_string(self._client_kexinit))
+        hash_data.extend(write_string(self._server_kexinit))
         hash_data.extend(write_string(server_host_key))
         hash_data.extend(write_string(client_public_key))
         hash_data.extend(write_string(server_public_key))
-        hash_data.extend(self._shared_secret)  # type: ignore[arg-type]
+        hash_data.extend(self._shared_secret)
 
         self._exchange_hash = default_crypto_backend.hash_data(
             "sha256", bytes(hash_data)
@@ -789,12 +809,14 @@ class KeyExchange:
         hash_data = bytearray()
 
         # Client version string
-        client_version = self._transport._client_version or "SSH-2.0-SpindleX_1.0"
-        hash_data.extend(write_string(client_version))
+        if self._transport._client_version is None:
+            raise CryptoException("Client version string not set for DH exchange hash")
+        hash_data.extend(write_string(self._transport._client_version))
 
         # Server version string
-        server_version = self._transport._server_version or "SSH-2.0-Unknown"
-        hash_data.extend(write_string(server_version))
+        if self._transport._server_version is None:
+            raise CryptoException("Server version string not set for DH exchange hash")
+        hash_data.extend(write_string(self._transport._server_version))
 
         # Client KEXINIT
         if self._client_kexinit is None:
@@ -970,15 +992,27 @@ class KeyExchange:
 
     def generate_keys(self) -> tuple[bytes, bytes, bytes, bytes]:
         """
-        Generate session keys from shared secret.
+        Return session keys derived during key exchange.
+
+        .. deprecated::
+            Access keys via the Transport object after key exchange completes.
+            This method will be removed in v1.0.
 
         Returns:
             Tuple of (encryption_key_c2s, encryption_key_s2c, mac_key_c2s, mac_key_s2c)
 
         Raises:
-            CryptoException: If key generation fails
+            CryptoException: If key exchange has not been completed yet
         """
-        if not all(
+        import warnings
+
+        warnings.warn(
+            "KeyExchange.generate_keys() is deprecated and will be removed in v1.0. "
+            "Access keys via the Transport object after key exchange completes.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if not hasattr(self, "_encryption_key_c2s") or not all(
             [
                 self._encryption_key_c2s,
                 self._encryption_key_s2c,

--- a/spindlex/transport/transport.py
+++ b/spindlex/transport/transport.py
@@ -61,6 +61,7 @@ from ..protocol.constants import (
     MSG_CHANNEL_WINDOW_ADJUST,
     MSG_DEBUG,
     MSG_DISCONNECT,
+    MSG_EXT_INFO,
     MSG_GLOBAL_REQUEST,
     MSG_IGNORE,
     MSG_KEXDH_INIT,
@@ -72,6 +73,7 @@ from ..protocol.constants import (
     MSG_SERVICE_ACCEPT,
     MSG_SERVICE_REQUEST,
     MSG_USERAUTH_FAILURE,
+    MSG_USERAUTH_PK_OK,
     MSG_USERAUTH_REQUEST,
     MSG_USERAUTH_SUCCESS,
     PACKET_LENGTH_SIZE,
@@ -121,6 +123,8 @@ _CIPHER_BLOCK_SIZES = {
     "aes192-ctr": 16,
     "aes256-ctr": 16,
 }
+
+_AEAD_CIPHERS: frozenset[str] = frozenset(["chacha20-poly1305@openssh.com"])
 
 
 class PacketProfiler:
@@ -282,6 +286,8 @@ class Transport:
         self._logger = logging.getLogger(__name__)
         self._strict_kex = False
         self._stop_event = threading.Event()
+        self._kex_thread: Optional[threading.Thread] = None
+        self._server_key: Optional[Any] = None
 
         self._buffer_size = 32768
         env_buffer_size = os.environ.get("SPINDLEX_BUFFER_SIZE")
@@ -1500,7 +1506,7 @@ class Transport:
         with self._lock:
             self._active = False
             self._stop_event.set()
-            kex_thread = getattr(self, "_kex_thread", None)
+            kex_thread = self._kex_thread
             channels_snapshot = list(self._channels.values())
             sock = self._socket
 
@@ -1670,7 +1676,7 @@ class Transport:
             # _check_rekey / _send_packet observers see a consistent snapshot.
             with self._lock:
                 self._kex_in_progress = False
-                self._kex_thread = None  # type: ignore[assignment]
+                self._kex_thread = None
                 self._bytes_since_rekey = 0
                 self._last_rekey_time = time.time()
                 self._kex_condition.notify_all()
@@ -1863,8 +1869,7 @@ class Transport:
             # ALWAYS increment sequence number for EVERY packet received
             self._sequence_number_in = (self._sequence_number_in + 1) & 0xFFFFFFFF
 
-            # 7 = MSG_EXT_INFO (RFC 8308)
-            if msg.msg_type in [MSG_IGNORE, MSG_DEBUG, 7]:
+            if msg.msg_type in [MSG_IGNORE, MSG_DEBUG, MSG_EXT_INFO]:
                 return HandledMessage() if single_pump else None  # type: ignore[return-value]
 
             if msg.msg_type == MSG_DISCONNECT:
@@ -1918,7 +1923,7 @@ class Transport:
                 if (
                     self._kex_in_progress
                     and not getattr(self, "_is_async", False)
-                    and threading.current_thread() != getattr(self, "_kex_thread", None)
+                    and threading.current_thread() != self._kex_thread
                 ):
                     # We should not be here if called from _recv_message or _expect_message
                     # as they have their own yielding loops, but for safety:
@@ -1975,8 +1980,7 @@ class Transport:
                     # If no rekeying or we are the rekeying thread, proceed to read
                     if (
                         not self._kex_in_progress
-                        or threading.current_thread()
-                        == getattr(self, "_kex_thread", None)
+                        or threading.current_thread() == self._kex_thread
                     ):
                         break
 
@@ -2021,8 +2025,7 @@ class Transport:
                     # If no rekeying or we are the rekeying thread, proceed to read
                     if (
                         not self._kex_in_progress
-                        or threading.current_thread()
-                        == getattr(self, "_kex_thread", None)
+                        or threading.current_thread() == self._kex_thread
                     ):
                         break
 
@@ -2182,7 +2185,8 @@ class Transport:
     def _encrypt_packet(self, packet: bytes) -> bytes:
         """Encrypt SSH packet and add MAC if needed."""
         if getattr(self, "_cipher_out_active", None) == "chacha20-poly1305@openssh.com":
-            assert self._chacha20_key_out is not None
+            if self._chacha20_key_out is None:
+                raise TransportException("ChaCha20 outbound key not initialised")
             return self._crypto_backend.chacha20_poly1305_encrypt(
                 self._chacha20_key_out,
                 self._sequence_number_out,
@@ -2236,7 +2240,6 @@ class Transport:
         # active encryption cipher) not the negotiated _cipher_c2s, because
         # NEWKEYS is sent before encryption is activated and must use standard
         # alignment even though _cipher_c2s may already be set to chacha20.
-        _AEAD_CIPHERS = frozenset(["chacha20-poly1305@openssh.com"])
         active_cipher = getattr(self, "_cipher_out_active", None)
         length_overhead = 0 if active_cipher in _AEAD_CIPHERS else PACKET_LENGTH_SIZE
         padding_length = block_size - (
@@ -2277,7 +2280,8 @@ class Transport:
                 if not self._active:
                     return b""
                 raise TransportException("Short read while receiving packet length")
-            assert self._chacha20_key_in is not None
+            if self._chacha20_key_in is None:
+                raise TransportException("ChaCha20 inbound key not initialised")
             plain_length = self._crypto_backend.chacha20_poly1305_decrypt_length(
                 self._chacha20_key_in, self._sequence_number_in, enc_length
             )
@@ -2394,9 +2398,12 @@ class Transport:
         #   short, non-blocking buffer slices.
         # * ``self._read_lock`` serializes the actual blocking ``socket.recv``
         #   call so two threads cannot race the kernel for the same socket.
-        # We do NOT hold ``self._read_lock`` while consuming from the buffer:
-        # any thread that already has buffered bytes available can return
-        # without contending with a peer that is blocked in ``recv``.
+        # Fast path: if the buffer already has enough bytes, consume under
+        # ``self._lock`` only — no need to acquire ``_read_lock`` at all.
+        # Slow path: acquire ``_read_lock``, re-check the buffer (another
+        # thread may have filled it while we waited), then block in recv().
+        # Buffer consumption in the slow path therefore happens under both
+        # ``_read_lock`` and ``self._lock``.
         while True:
             with self._lock:
                 if len(self._packet_buffer) >= length:
@@ -2536,8 +2543,7 @@ class Transport:
                     # Client is just querying if the key is acceptable
                     if self._server_interface.check_auth_publickey(username, key):
                         # Send PK_OK to indicate key is acceptable
-                        # MSG_USERAUTH_PK_OK = 60
-                        pk_ok = Message(60)
+                        pk_ok = Message(MSG_USERAUTH_PK_OK)
                         pk_ok._data.extend(write_string(algo_name))
                         pk_ok._data.extend(write_string(key_blob))
                         self._send_message(pk_ok)

--- a/tests/client/test_ssh_client_unit.py
+++ b/tests/client/test_ssh_client_unit.py
@@ -1245,3 +1245,34 @@ class TestAuthenticateKeyFilenameSkippedWhenPkeyAlreadySet:
         with patch("spindlex.client.ssh_client.PKey") as mock_pkey_cls:
             client._authenticate("user", pkey=pkey, key_filename="/path/key")
             mock_pkey_cls.from_private_key_file.assert_not_called()
+
+
+# ===========================================================================
+# SSHClient.save_host_keys - copy_from branch
+# ===========================================================================
+
+
+class TestSaveHostKeys:
+    def test_save_host_keys_same_filename_saves_directly(self, tmp_path):
+        client = SSHClient()
+        filename = str(tmp_path / "known_hosts")
+        client._host_key_storage._filename = filename
+        with patch.object(client._host_key_storage, "save") as mock_save:
+            client.save_host_keys(filename)
+            mock_save.assert_called_once()
+
+    def test_save_host_keys_different_filename_copies_and_saves(self, tmp_path):
+        from spindlex.hostkeys.storage import HostKeyStorage
+
+        client = SSHClient()
+        original_filename = str(tmp_path / "known_hosts_orig")
+        new_filename = str(tmp_path / "known_hosts_new")
+        client._host_key_storage._filename = original_filename
+
+        new_storage = MagicMock(spec=HostKeyStorage)
+        with patch(
+            "spindlex.client.ssh_client.HostKeyStorage", return_value=new_storage
+        ):
+            client.save_host_keys(new_filename)
+            new_storage.copy_from.assert_called_once()
+            new_storage.save.assert_called_once()

--- a/tests/crypto/test_crypto_backend_extra.py
+++ b/tests/crypto/test_crypto_backend_extra.py
@@ -39,3 +39,17 @@ def test_backend_decrypt_length_passthrough():
     # Should return data as is for all ciphers now
     data = b"1234"
     assert backend.decrypt_length("aes256-ctr", b"k" * 32, b"iv" * 16, data) == data
+
+
+def test_backend_hash_data_wraps_unexpected_exception():
+    """hash_data wraps non-CryptoException errors in CryptoException."""
+    from unittest.mock import MagicMock, patch
+
+    from cryptography.hazmat.primitives import hashes
+
+    backend = CryptographyBackend()
+    mock_digest = MagicMock()
+    mock_digest.update.side_effect = RuntimeError("digest exploded")
+    with patch.object(hashes, "Hash", return_value=mock_digest):
+        with pytest.raises(CryptoException, match="Hash operation failed"):
+            backend.hash_data("sha256", b"data")

--- a/tests/hostkeys/test_hostkeys_extra.py
+++ b/tests/hostkeys/test_hostkeys_extra.py
@@ -81,3 +81,27 @@ def test_auto_add_policy_storage_failure():
         policy.missing_host_key(client, hostname, key)
 
     assert "Failed to persist new host key" in str(excinfo.value)
+
+
+def test_auto_add_policy_without_accept_risk_emits_warning():
+    """AutoAddPolicy() with accept_risk=False emits UserWarning."""
+    import warnings
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        policy = AutoAddPolicy(accept_risk=False)
+        assert policy._accept_risk is False
+    user_warnings = [w for w in caught if issubclass(w.category, UserWarning)]
+    assert len(user_warnings) == 1
+    assert "insecure" in str(user_warnings[0].message).lower()
+
+
+def test_auto_add_policy_missing_host_key_no_storage():
+    """missing_host_key logs debug when client has no host key storage."""
+    policy = AutoAddPolicy(accept_risk=True)
+    client = MagicMock(spec=[])  # no _host_key_storage attribute
+    key = MagicMock()
+    key.algorithm_name = "ssh-ed25519"
+    key.get_fingerprint.return_value = "SHA256:abc..."
+    # Should not raise; the else branch logs a debug message
+    policy.missing_host_key(client, "host.example.com", key)

--- a/tests/hostkeys/test_hostkeys_storage.py
+++ b/tests/hostkeys/test_hostkeys_storage.py
@@ -114,3 +114,35 @@ class TestHostKeyStorage:
 
         # Test unsupported type
         assert storage._create_key_from_type_and_data("unknown-type", b"data") is None
+
+
+class TestCopyFrom:
+    def test_copy_from_merges_new_hostname(self, tmp_path):
+        src = HostKeyStorage(str(tmp_path / "src"))
+        dst = HostKeyStorage(str(tmp_path / "dst"))
+        key = MagicMock(spec=Ed25519Key)
+        src.add("host1", key)
+        dst.copy_from(src)
+        assert dst.get_all("host1") == [key]
+
+    def test_copy_from_skips_duplicate_keys(self, tmp_path):
+        src = HostKeyStorage(str(tmp_path / "src"))
+        dst = HostKeyStorage(str(tmp_path / "dst"))
+        key = MagicMock(spec=Ed25519Key)
+        src.add("host1", key)
+        dst.add("host1", key)  # already present
+        dst.copy_from(src)
+        assert dst.get_all("host1") == [key]  # not duplicated
+
+    def test_copy_from_appends_new_key_to_existing_hostname(self, tmp_path):
+        src = HostKeyStorage(str(tmp_path / "src"))
+        dst = HostKeyStorage(str(tmp_path / "dst"))
+        key1 = MagicMock(spec=Ed25519Key)
+        key2 = MagicMock(spec=Ed25519Key)
+        dst.add("host1", key1)
+        src.add("host1", key2)
+        dst.copy_from(src)
+        all_keys = dst.get_all("host1")
+        assert key1 in all_keys
+        assert key2 in all_keys
+        assert len(all_keys) == 2

--- a/tests/transport/test_async_transport_unit.py
+++ b/tests/transport/test_async_transport_unit.py
@@ -88,9 +88,11 @@ class TestAsyncTransportUnit:
     @pytest.mark.asyncio
     async def test_recv_version_async_no_reader_raises(self, transport):
         with pytest.raises(TransportException, match="Transport not initialized"):
-            await transport.recv_version_async() if hasattr(
-                transport, "recv_version_async"
-            ) else await transport._recv_version_async()
+            (
+                await transport.recv_version_async()
+                if hasattr(transport, "recv_version_async")
+                else await transport._recv_version_async()
+            )
 
     @pytest.mark.asyncio
     async def test_send_message_bridge_from_other_thread(self, transport):

--- a/tests/transport/test_kex_coverage.py
+++ b/tests/transport/test_kex_coverage.py
@@ -138,6 +138,24 @@ class TestComputeEcdhExchangeHashGuards:
         with pytest.raises(CryptoException, match="Missing shared secret for ECDH"):
             kex._compute_ecdh_exchange_hash(b"hostkey", b"serverpub", b"sig")
 
+    def test_raises_when_client_version_is_none(self):
+        kex = self._base_kex()
+        _set_kexinit_blobs(kex)
+        kex._transport._client_version = None
+        with pytest.raises(
+            CryptoException, match="Client version string not set for ECDH"
+        ):
+            kex._compute_ecdh_exchange_hash(b"hostkey", b"serverpub", b"sig")
+
+    def test_raises_when_server_version_is_none(self):
+        kex = self._base_kex()
+        _set_kexinit_blobs(kex)
+        kex._transport._server_version = None
+        with pytest.raises(
+            CryptoException, match="Server version string not set for ECDH"
+        ):
+            kex._compute_ecdh_exchange_hash(b"hostkey", b"serverpub", b"sig")
+
     def test_override_client_pub_key_works(self):
         """client_ecdh_public_key parameter overrides self._ecdh_public_key_bytes."""
         kex = self._base_kex()
@@ -209,6 +227,93 @@ class TestComputeExchangeHashGuards:
             client_dh_public_mpint=write_mpint(99),
         )
         assert kex._exchange_hash is not None
+
+    def test_raises_when_client_version_is_none(self):
+        kex = self._base_kex()
+        _set_kexinit_blobs(kex)
+        kex._transport._client_version = None
+        with pytest.raises(
+            CryptoException, match="Client version string not set for DH"
+        ):
+            kex._compute_exchange_hash(b"hostkey", b"serverpub", b"sig")
+
+    def test_raises_when_server_version_is_none(self):
+        kex = self._base_kex()
+        _set_kexinit_blobs(kex)
+        kex._transport._server_version = None
+        with pytest.raises(
+            CryptoException, match="Server version string not set for DH"
+        ):
+            kex._compute_exchange_hash(b"hostkey", b"serverpub", b"sig")
+
+
+# ---------------------------------------------------------------------------
+# _compute_curve25519_exchange_hash guard paths
+# ---------------------------------------------------------------------------
+
+
+class TestComputeCurve25519ExchangeHashGuards:
+    def _base_kex(self) -> KeyExchange:
+        kex, _ = _make_kex()
+        from spindlex.protocol.utils import write_mpint
+
+        kex._shared_secret = write_mpint(99)
+        return kex
+
+    def test_raises_when_client_version_is_none(self):
+        kex = self._base_kex()
+        _set_kexinit_blobs(kex)
+        kex._transport._client_version = None
+        with pytest.raises(
+            CryptoException, match="Client version string not set for Curve25519"
+        ):
+            kex._compute_curve25519_exchange_hash(
+                b"hostkey", b"\x04" + b"\xaa" * 32, b"serverpub"
+            )
+
+    def test_raises_when_server_version_is_none(self):
+        kex = self._base_kex()
+        _set_kexinit_blobs(kex)
+        kex._transport._server_version = None
+        with pytest.raises(
+            CryptoException, match="Server version string not set for Curve25519"
+        ):
+            kex._compute_curve25519_exchange_hash(
+                b"hostkey", b"\x04" + b"\xaa" * 32, b"serverpub"
+            )
+
+    def test_raises_when_client_kexinit_is_none(self):
+        kex = self._base_kex()
+        kex._client_kexinit = None
+        kex._server_kexinit = b"\x02" * 16
+        with pytest.raises(
+            CryptoException, match="Missing client KEXINIT for Curve25519"
+        ):
+            kex._compute_curve25519_exchange_hash(
+                b"hostkey", b"\x04" + b"\xaa" * 32, b"serverpub"
+            )
+
+    def test_raises_when_server_kexinit_is_none(self):
+        kex = self._base_kex()
+        kex._client_kexinit = b"\x01" * 16
+        kex._server_kexinit = None
+        with pytest.raises(
+            CryptoException, match="Missing server KEXINIT for Curve25519"
+        ):
+            kex._compute_curve25519_exchange_hash(
+                b"hostkey", b"\x04" + b"\xaa" * 32, b"serverpub"
+            )
+
+    def test_raises_when_shared_secret_is_none(self):
+        kex = self._base_kex()
+        _set_kexinit_blobs(kex)
+        kex._shared_secret = None
+        with pytest.raises(
+            CryptoException, match="Missing shared secret for Curve25519"
+        ):
+            kex._compute_curve25519_exchange_hash(
+                b"hostkey", b"\x04" + b"\xaa" * 32, b"serverpub"
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/transport/test_kex_coverage.py
+++ b/tests/transport/test_kex_coverage.py
@@ -334,10 +334,7 @@ class TestDHPublicKeyGuard:
         mock_pub.public_numbers.return_value = mock_pub_numbers
         mock_priv.public_key.return_value = mock_pub
 
-        with (
-            patch("spindlex.transport.kex.dh") as mock_dh_module,
-            patch("spindlex.transport.kex.default_backend"),
-        ):
+        with patch("spindlex.transport.kex.dh") as mock_dh_module:
             mock_params = MagicMock()
             mock_params.generate_private_key.return_value = mock_priv
             mock_dh_module.DHParameterNumbers.return_value.parameters.return_value = (

--- a/tests/transport/test_kex_unit.py
+++ b/tests/transport/test_kex_unit.py
@@ -473,23 +473,8 @@ class TestStartKex:
         kex, transport = make_kex()
         transport._peer_kexinit = None  # not yet exchanged
 
-        with (
-            patch.object(kex, "_send_kexinit") as mock_send,
-            patch.object(kex, "_receive_kexinit") as mock_recv,
-            patch.object(kex, "_negotiate_algorithms"),
-            patch.object(kex, "_perform_client_kex"),
-            patch.object(kex, "_generate_session_keys"),
-            patch.object(kex, "_send_newkeys"),
-            patch.object(kex, "_receive_newkeys"),
-        ):
-            # After _receive_kexinit is called, simulate peer_kexinit being set
-            def set_peer(*a, **kw):
-                transport._peer_kexinit = _make_peer_kexinit()
-
-            mock_recv.side_effect = set_peer
+        with pytest.raises(CryptoException, match="Peer KEXINIT not received"):
             kex.start_kex()
-            mock_send.assert_called_once()
-            mock_recv.assert_called_once()
 
     def test_start_kex_skips_kexinit_when_peer_already_set(self):
         kex, transport = make_kex()
@@ -580,7 +565,6 @@ class TestDhGroup14Sha256Client:
 
         with (
             patch("spindlex.transport.kex.dh") as mock_dh_module,
-            patch("spindlex.transport.kex.default_backend"),
             patch.object(kex, "_verify_server_signature"),
         ):
             mock_params = MagicMock()
@@ -606,7 +590,6 @@ class TestDhGroup14Sha256Client:
 
         with (
             patch("spindlex.transport.kex.dh") as mock_dh_module,
-            patch("spindlex.transport.kex.default_backend"),
             patch.object(kex, "_verify_server_signature"),
         ):
             mock_params = MagicMock()
@@ -632,7 +615,6 @@ class TestDhGroup14Sha256Client:
 
         with (
             patch("spindlex.transport.kex.dh") as mock_dh_module,
-            patch("spindlex.transport.kex.default_backend"),
             patch.object(kex, "_verify_server_signature"),
         ):
             mock_params = MagicMock()
@@ -660,7 +642,6 @@ class TestDhGroup14Sha256Client:
 
         with (
             patch("spindlex.transport.kex.dh") as mock_dh_module,
-            patch("spindlex.transport.kex.default_backend"),
             patch.object(kex, "_verify_server_signature"),
         ):
             mock_params = MagicMock()
@@ -684,10 +665,7 @@ class TestDhGroup14Sha256Client:
         reply = _make_dh_reply_msg(b"hostkey", 1, b"sig")
         transport._expect_message.return_value = reply
 
-        with (
-            patch("spindlex.transport.kex.dh") as mock_dh_module,
-            patch("spindlex.transport.kex.default_backend"),
-        ):
+        with patch("spindlex.transport.kex.dh") as mock_dh_module:
             mock_params = MagicMock()
             mock_params.generate_private_key.return_value = mock_priv
             mock_params.parameter_numbers.return_value = MagicMock()
@@ -723,7 +701,6 @@ class TestEcdhNistp256Client:
 
         with (
             patch("cryptography.hazmat.primitives.asymmetric.ec") as mock_ec_module,
-            patch("spindlex.transport.kex.default_backend"),
             patch("spindlex.transport.kex.serialization"),
             patch.object(kex, "_verify_server_signature"),
         ):
@@ -748,7 +725,6 @@ class TestEcdhNistp256Client:
 
         with (
             patch("cryptography.hazmat.primitives.asymmetric.ec") as mock_ec_module,
-            patch("spindlex.transport.kex.default_backend"),
             patch("spindlex.transport.kex.serialization"),
             patch.object(kex, "_verify_server_signature"),
         ):

--- a/tests/transport/test_transport_coverage.py
+++ b/tests/transport/test_transport_coverage.py
@@ -125,3 +125,26 @@ class TestTransportCoverage:
         msg = ChannelCloseMessage(1)
         t._handle_channel_close(msg)
         chan._handle_close.assert_called_once()
+
+
+class TestChaCha20KeyGuards:
+    def test_encrypt_raises_when_chacha20_key_out_is_none(self):
+        t = _make_transport()
+        t._cipher_out_active = "chacha20-poly1305@openssh.com"
+        t._chacha20_key_out = None
+        with pytest.raises(
+            TransportException, match="ChaCha20 outbound key not initialised"
+        ):
+            t._encrypt_packet(b"data")
+
+    def test_recv_packet_raises_when_chacha20_key_in_is_none(self):
+        from unittest.mock import patch as _patch
+
+        t = _make_transport()
+        t._cipher_in_active = "chacha20-poly1305@openssh.com"
+        t._chacha20_key_in = None
+        with _patch.object(t, "_recv_bytes", return_value=b"\x00\x00\x00\x04"):
+            with pytest.raises(
+                TransportException, match="ChaCha20 inbound key not initialised"
+            ):
+                t._recv_packet()


### PR DESCRIPTION
## Description

- Remove SHA-1 from CryptographyBackend hash algorithm map
- Add MSG_EXT_INFO constant; replace magic protocol numbers with named constants
- Replace dead KEX fallback with explicit CryptoException guard
- Replace assert statements with explicit guards in crypto/KEX paths
- Move _AEAD_CIPHERS frozenset to module level (was re-allocated per call)
- Fix WarningPolicy docstring; add logger warning to AutoAddPolicy
- Add HostKeyStorage.copy_from(); fix save_host_keys() encapsulation
- Raise ConfigurationException for unsupported compress/gss_kex options
- Declare _kex_thread and _server_key in Transport.__init__
- Fix misleading _recv_bytes lock ordering comment
- Remove deprecated default_backend() calls from kex.py, backend.py, pkey.py
- Remove no-op try/except wrapper in _perform_dh_group14_sha256
- Deprecate KeyExchange.generate_keys() with DeprecationWarning
- Replace version string silent fallbacks with explicit CryptoException guards
- Replace hardcoded "utf-8" literals with SSH_STRING_ENCODING in ssh_client.py
- Add [tool.isort] and [tool.black] configs to pyproject.toml
- Update stale test patches after default_backend removal

Fixes # (issue)

## Type of Change

Select exactly one option. These stable tokens are parsed by CI and release automation.

- [ ] bug - Bug fix; creates a patch release.
- [x] feature - Feature or stabilization work intended for the current beta minor line; creates a patch release before 1.0.
- [ ] feature-minor - Real feature intended to advance the beta minor line; creates a minor release before 1.0.
- [ ] breaking - Breaking beta change; creates a minor release before 1.0.
- [ ] docs - Documentation-only change; no release.
- [ ] refactor - Non-functional cleanup or refactor; no release.
- [ ] test - Test-only change; no release.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. -->

- [x] **Unit Tests**: `pytest tests/test_...`
- [ ] **Integration Tests**: `pytest -m integration`
- [x] **Manual Test**: (Please describe)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
