### PR TITLE
chore(release): v0.7.2 [publish release]

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,16 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [0.7.2] - 2026-05-30
+
 ### Fixed
 *   Made the protected publish job idempotent after partial PyPI uploads, added a manual recovery mode for already-published versions, configured Git identity before annotated tag creation, and finalized changelog sections for both new and recovered release-version PR branches before release-note extraction.
-
-## [0.7.1] - 2026-05-29
-
-### Summary
-This maintainer-facing readiness entry documents the repository lifecycle work
-released in 0.7.1.
-
-## [0.7.2] - Unreleased
 
 ### Changed
 *   Removed SHA-1 from `CryptographyBackend.HASH_ALGORITHMS` — SHA-1 now raises `CryptoException` if requested, enforcing the no-SHA-1 security invariant at the backend layer.
@@ -59,6 +53,12 @@ released in 0.7.1.
 
 ### Verification
 *   Read the Docs continues to build from `.readthedocs.yaml` through `mkdocs.yml`; newly added public docs are explicitly surfaced in the MkDocs navigation rather than being included by the Read the Docs config directly.
+
+## [0.7.1] - 2026-05-29
+
+### Summary
+This maintainer-facing readiness entry documents the repository lifecycle work
+released in 0.7.1.
 
 ## [0.7.0] - 2026-05-16
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "spindlex"
-version = "0.7.1"
+version = "0.7.2"
 
 description = "A modern, high-performance SSHv2 and SFTP client/server library"
 readme = "README.md"

--- a/scripts/finalize_changelog_release.py
+++ b/scripts/finalize_changelog_release.py
@@ -54,7 +54,9 @@ def finalize_changelog(content: str, *, version: str, release_date: str) -> str:
 
         unreleased_end = _section_end(lines, unreleased_index)
         version_end = _section_end(lines, version_index)
-        unreleased_body = _trim_blank_edges(lines[unreleased_index + 1 : unreleased_end])
+        unreleased_body = _trim_blank_edges(
+            lines[unreleased_index + 1 : unreleased_end]
+        )
         version_body = _trim_blank_edges(lines[version_index + 1 : version_end])
         combined_body = unreleased_body.copy()
         if combined_body and version_body:

--- a/scripts/finalize_changelog_release.py
+++ b/scripts/finalize_changelog_release.py
@@ -14,18 +14,63 @@ UNRELEASED_HEADING = "## [Unreleased]"
 RELEASE_HEADING = re.compile(r"^## \[(?P<version>[^\]]+)\](?:\s+-\s+.*)?$")
 
 
+def _section_end(lines: list[str], start: int) -> int:
+    for index in range(start + 1, len(lines)):
+        if RELEASE_HEADING.match(lines[index]):
+            return index
+    return len(lines)
+
+
+def _trim_blank_edges(lines: list[str]) -> list[str]:
+    start = 0
+    end = len(lines)
+    while start < end and not lines[start].strip():
+        start += 1
+    while end > start and not lines[end - 1].strip():
+        end -= 1
+    return lines[start:end]
+
+
 def finalize_changelog(content: str, *, version: str, release_date: str) -> str:
     lines = content.splitlines()
-    if any(
-        (match := RELEASE_HEADING.match(line)) and match.group("version") == version
-        for line in lines
-    ):
-        return content if content.endswith("\n") else f"{content}\n"
-
     try:
         unreleased_index = lines.index(UNRELEASED_HEADING)
     except ValueError as exc:
         raise ValueError("Could not find ## [Unreleased] in changelog.") from exc
+
+    version_index = next(
+        (
+            index
+            for index, line in enumerate(lines)
+            if (match := RELEASE_HEADING.match(line))
+            and match.group("version") == version
+        ),
+        None,
+    )
+    if version_index is not None:
+        existing_heading = lines[version_index]
+        if "Unreleased" not in existing_heading:
+            return content if content.endswith("\n") else f"{content}\n"
+
+        unreleased_end = _section_end(lines, unreleased_index)
+        version_end = _section_end(lines, version_index)
+        unreleased_body = _trim_blank_edges(lines[unreleased_index + 1 : unreleased_end])
+        version_body = _trim_blank_edges(lines[version_index + 1 : version_end])
+        combined_body = unreleased_body.copy()
+        if combined_body and version_body:
+            combined_body.append("")
+        combined_body.extend(version_body)
+
+        del lines[version_index:version_end]
+        del lines[unreleased_index + 1 : unreleased_end]
+        lines[unreleased_index + 1 : unreleased_index + 1] = [
+            "",
+            f"## [{version}] - {release_date}",
+            "",
+            *combined_body,
+            "",
+        ]
+        return "\n".join(lines).rstrip() + "\n"
 
     insert_at = unreleased_index + 1
     release_heading = f"## [{version}] - {release_date}"

--- a/spindlex/_version.py
+++ b/spindlex/_version.py
@@ -1,7 +1,7 @@
 # spindlex/_version.py
 
-__version__ = "0.7.1"
-__version_info__ = (0, 7, 1)
+__version__ = "0.7.2"
+__version_info__ = (0, 7, 2)
 
 
 def get_version() -> str:

--- a/tests/scripts/test_finalize_changelog_release.py
+++ b/tests/scripts/test_finalize_changelog_release.py
@@ -56,6 +56,38 @@ def test_finalize_changelog_is_idempotent_for_existing_version():
     assert updated == content
 
 
+def test_finalize_changelog_dates_existing_unreleased_version_section():
+    content = """# Changelog
+
+## [Unreleased]
+
+### Fixed
+*   Release workflow fix.
+
+## [0.7.1] - 2026-05-29
+
+### Fixed
+*   Older fix.
+
+## [0.7.2] - Unreleased
+
+### Changed
+*   Security hardening.
+
+## [0.7.0] - 2026-05-16
+"""
+
+    updated = finalize_changelog_release.finalize_changelog(
+        content, version="0.7.2", release_date="2026-05-30"
+    )
+
+    assert "## [Unreleased]\n\n## [0.7.2] - 2026-05-30" in updated
+    assert updated.index("## [0.7.2]") < updated.index("## [0.7.1]")
+    assert "*   Release workflow fix." in updated
+    assert "*   Security hardening." in updated
+    assert "## [0.7.2] - Unreleased" not in updated
+
+
 def test_finalize_changelog_requires_unreleased_heading():
     try:
         finalize_changelog_release.finalize_changelog(


### PR DESCRIPTION
## Description

Protected release-version PR for v0.7.2.

Source PR: #187 https://github.com/stratza/spindlex/pull/187
Release type: patch

## Type of Change

- [ ] bug - Bug fix; creates a patch release.
- [ ] feature - Feature or stabilization work intended for the current beta minor line; creates a patch release before 1.0.
- [ ] feature-minor - Real feature intended to advance the beta minor line; creates a minor release before 1.0.
- [ ] breaking - Breaking beta change; creates a minor release before 1.0.
- [x] docs - Documentation-only change; no release.
- [ ] refactor - Non-functional cleanup or refactor; no release.
- [ ] test - Test-only change; no release.

## How Has This Been Tested?

- [x] Release compatibility matrix
- [x] Release integration
- [x] Release property tests
- [x] Release benchmark baseline
- [x] Focused release helper tests run locally with Python 3.11