### PR TITLE
docs: harden public adoption surfaces

### DIFF
--- a/.github/ISSUE_TEMPLATE/compatibility_report.yml
+++ b/.github/ISSUE_TEMPLATE/compatibility_report.yml
@@ -1,0 +1,109 @@
+name: Compatibility Report
+description: Report SpindleX behavior against a specific SSH/SFTP server or platform
+title: "[Compatibility]: "
+labels: ["compatibility", "triage"]
+assignees: []
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template when SpindleX works, partially works, or fails against a specific SSH/SFTP server, OS, or deployment environment.
+
+  - type: input
+    id: spindlex_version
+    attributes:
+      label: SpindleX Version
+      description: Run `python -c "import spindlex; print(spindlex.__version__)"`.
+      placeholder: "0.7.2"
+    validations:
+      required: true
+
+  - type: input
+    id: python_version
+    attributes:
+      label: Python Version
+      placeholder: "Python 3.12.3"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Client Operating System
+      multiple: true
+      options:
+        - Linux
+        - macOS
+        - Windows
+        - Docker / container
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: server
+    attributes:
+      label: SSH/SFTP Server
+      description: Include server family and version if known.
+      placeholder: "OpenSSH 9.6, Dropbear 2024.86, appliance firmware version, unknown"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: feature
+    attributes:
+      label: Tested Feature
+      multiple: true
+      options:
+        - SSH command execution
+        - SFTP upload
+        - SFTP download
+        - SFTP directory operations
+        - Password authentication
+        - Public key authentication
+        - Keyboard-interactive authentication
+        - GSSAPI / Kerberos
+        - Port forwarding
+        - Server mode
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: result
+    attributes:
+      label: Result
+      description: What worked, partially worked, or failed?
+      placeholder: "Connection succeeds, authentication succeeds, SFTP upload fails after the first chunk..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Minimal Reproduction
+      description: Provide the smallest code/configuration needed to reproduce or confirm the result.
+      render: python
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or Server Output
+      description: Paste relevant sanitized logs. Do not include passwords, private keys, tokens, or sensitive hostnames.
+      render: shell
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I removed secrets, private keys, passwords, and sensitive hostnames from this report.
+          required: true
+        - label: I checked the compatibility documentation before opening this report.
+          required: true
+

--- a/.github/ISSUE_TEMPLATE/usage_report.yml
+++ b/.github/ISSUE_TEMPLATE/usage_report.yml
@@ -1,0 +1,74 @@
+name: Real-World Usage Report
+description: Share how you are using SpindleX so the project can improve docs, examples, and compatibility
+title: "[Usage]: "
+labels: ["usage-report", "triage"]
+assignees: []
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Usage reports help us understand which workflows matter in the real world. Public reports should not include secrets, private infrastructure details, or customer data.
+
+  - type: dropdown
+    id: use_case
+    attributes:
+      label: Use Case
+      multiple: true
+      options:
+        - SSH command automation
+        - SFTP file transfer
+        - Backup / restore automation
+        - CI/CD or release automation
+        - Infrastructure operations
+        - Security tooling
+        - Internal platform tooling
+        - Server-side SSH/SFTP use
+        - Evaluation only
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: workflow
+    attributes:
+      label: Workflow Summary
+      description: Describe the workflow at a high level.
+      placeholder: "We use SpindleX to upload generated configuration artifacts to controlled Linux hosts over SFTP..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why SpindleX?
+      description: What made you try or choose SpindleX?
+      placeholder: "asyncio support, typed API, security defaults, modern algorithms, performance, simpler API..."
+    validations:
+      required: false
+
+  - type: textarea
+    id: gaps
+    attributes:
+      label: Gaps or Missing Docs
+      description: What was confusing, missing, or harder than expected?
+    validations:
+      required: false
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Optional high-level environment details.
+      placeholder: "Python 3.12, Linux containers, OpenSSH servers"
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: public_quote
+    attributes:
+      label: Public Use
+      options:
+        - label: Maintainers may quote or summarize this public report in docs or release notes.
+          required: false
+

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,8 +11,8 @@ authors:
   given-names: "Adi"
   alias: "adirothbuilds"
 title: "SpindleX"
-version: 0.7.0
-date-released: 2026-05-16
+version: 0.7.2
+date-released: 2026-05-30
 url: "https://github.com/stratza/spindlex"
 abstract: "A modern, high-performance SSHv2 and SFTP library focused on speed, security, and developer experience."
 keywords:

--- a/README.md
+++ b/README.md
@@ -1,13 +1,3 @@
-# SpindleX
-
-SpindleX is a typed Python SSHv2 and SFTP library for async automation,
-secure file transfer, port forwarding, and controlled SSH/SFTP server workflows.
-It targets Python 3.9+ and focuses on modern SSH algorithms, strict host key
-verification, minimal runtime dependencies, and a clear public API.
-
-Use SpindleX when you need Python-native SSH/SFTP automation with modern
-security defaults, first-class `asyncio`, and production-facing documentation.
-
 <div align="center">
 
 <img src="https://capsule-render.vercel.app/api?type=waving&amp;color=gradient&amp;customColorList=18,18,18,48,25,52,18,18,18&amp;height=200&amp;section=header&amp;text=SpindleX&amp;fontSize=80&amp;fontColor=bb86fc&amp;fontAlignY=45&amp;desc=High-Performance%20SSH%20and%20SFTP%20for%20Python&amp;descSize=22&amp;descColor=b39ddb&amp;descAlignY=70&amp;animation=fadeIn" width="100%" />
@@ -29,9 +19,18 @@ security defaults, first-class `asyncio`, and production-facing documentation.
 
 </div>
 
+<!--
+SpindleX is a typed Python SSHv2 and SFTP library for async automation, secure
+file transfer, port forwarding, and controlled SSH/SFTP server workflows. It
+targets Python 3.9+ and focuses on modern SSH algorithms, strict host key
+verification, minimal runtime dependencies, first-class asyncio support, and a
+clear public API. Use SpindleX when you need Python-native SSH/SFTP automation
+with modern security defaults and production-facing documentation.
+-->
+
 ---
 
-## Overview
+## ⚡ Overview
 
 **SpindleX** is a modern SSH protocol implementation for Python 3.9+. It is
 designed for high-performance automation and secure file transfers, providing a
@@ -40,7 +39,7 @@ clean alternative to legacy SSH libraries.
 > [!NOTE]
 > **0.7.x - ChaCha20-Poly1305 & SFTP throughput era.** This release line adds full `chacha20-poly1305@openssh.com` support as the preferred cipher, adaptive SFTP write chunks via `limits@openssh.com` (up to 255 KB), and a hardened async transport. Review [SECURITY.md](SECURITY.md), [production usage expectations](docs/production-usage.md), and [compatibility policy](docs/compatibility.md) before deploying in production-facing workflows.
 
-### Key Features
+### 🔥 Key Features
 
 - 🚀 **High Performance**: Adaptive SFTP write chunks up to 255 KB via `limits@openssh.com` negotiation, pipelined transfers, and zero-copy internal buffering.
 - 🔒 **ChaCha20-Poly1305**: Preferred AEAD cipher - no separate MAC pass, full Terrapin-defense strict-KEX, on par with leading SSH libraries.
@@ -52,7 +51,7 @@ clean alternative to legacy SSH libraries.
 
 ---
 
-## Use SpindleX When
+## ✅ Use SpindleX When
 
 - You need SSH command execution or SFTP automation from Python.
 - You want both synchronous and `asyncio` client APIs in one package.
@@ -60,14 +59,14 @@ clean alternative to legacy SSH libraries.
 - You want a small dependency surface backed by the `cryptography` package.
 - You need a library with public production, compatibility, security, and release policies.
 
-## Not the Right Fit When
+## 🚫 Not the Right Fit When
 
 - You need universal compatibility with legacy SSH servers or weak algorithms.
 - You need production use of unknown-host auto-acceptance policies.
 - You need every OpenSSH server feature or appliance-specific SSH behavior.
 - You need a stable `1.0.0` API today; SpindleX is still in beta.
 
-## Why SpindleX?
+## 💎 Why SpindleX?
 
 - 💼 **Business Friendly**: MIT Licensed. Permissive use for commercial and proprietary projects.
 - 📖 **Maintainable Code**: Modular architecture designed for clarity and easier security auditing.
@@ -76,7 +75,7 @@ clean alternative to legacy SSH libraries.
 
 ---
 
-## Positioning
+## 🧭 Positioning
 
 | Need | SpindleX fit |
 |:---|:---|
@@ -92,7 +91,7 @@ protocol behavior over broad legacy compatibility.
 
 ---
 
-## Tech Stack
+## 🛠️ Tech Stack
 
 <div align="left">
 
@@ -108,7 +107,7 @@ protocol behavior over broad legacy compatibility.
 
 ---
 
-## Quick Start
+## 🚀 Quick Start
 
 ### Installation
 
@@ -159,7 +158,7 @@ asyncio.run(main())
 
 ---
 
-## Performance Benchmarks
+## 📊 Performance Benchmarks
 
 SpindleX is optimized for high-throughput environments. The 0.7.x line brings SFTP upload throughput in line with leading SSH libraries and adds ChaCha20-Poly1305 as the preferred cipher.
 
@@ -178,7 +177,7 @@ SpindleX is optimized for high-throughput environments. The 0.7.x line brings SF
 
 ---
 
-## Security
+## 🛡️ Security
 
 - **Verification Enforced**: Host key verification is mandatory by default.
 - **Log Sanitization**: Credentials and sensitive data are automatically filtered from logs.
@@ -189,7 +188,7 @@ SpindleX is optimized for high-throughput environments. The 0.7.x line brings SF
 
 ---
 
-## Documentation
+## 📚 Documentation
 
 - [Quick Start](https://spindlex.readthedocs.io/en/latest/quickstart/)
 - [User Guide](https://spindlex.readthedocs.io/en/latest/user_guide/)
@@ -199,7 +198,7 @@ SpindleX is optimized for high-throughput environments. The 0.7.x line brings SF
 - [Compatibility](https://spindlex.readthedocs.io/en/latest/compatibility/)
 - [Security](https://spindlex.readthedocs.io/en/latest/security/)
 
-## Contributing
+## 🤝 Contributing
 
 Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for the GitHub entry point and [docs/contributing.md](docs/contributing.md) for the maintained guide.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+# SpindleX
+
+SpindleX is a typed Python SSHv2 and SFTP library for async automation,
+secure file transfer, port forwarding, and controlled SSH/SFTP server workflows.
+It targets Python 3.9+ and focuses on modern SSH algorithms, strict host key
+verification, minimal runtime dependencies, and a clear public API.
+
+Use SpindleX when you need Python-native SSH/SFTP automation with modern
+security defaults, first-class `asyncio`, and production-facing documentation.
+
 <div align="center">
 
 <img src="https://capsule-render.vercel.app/api?type=waving&amp;color=gradient&amp;customColorList=18,18,18,48,25,52,18,18,18&amp;height=200&amp;section=header&amp;text=SpindleX&amp;fontSize=80&amp;fontColor=bb86fc&amp;fontAlignY=45&amp;desc=High-Performance%20SSH%20and%20SFTP%20for%20Python&amp;descSize=22&amp;descColor=b39ddb&amp;descAlignY=70&amp;animation=fadeIn" width="100%" />
@@ -21,14 +31,16 @@
 
 ---
 
-## ⚡ Overview
+## Overview
 
-**SpindleX** is a modern SSH protocol implementation for Python 3.9+. It is designed for high-performance automation and secure file transfers, providing a clean alternative to legacy SSH libraries.
+**SpindleX** is a modern SSH protocol implementation for Python 3.9+. It is
+designed for high-performance automation and secure file transfers, providing a
+clean alternative to legacy SSH libraries.
 
 > [!NOTE]
 > **0.7.x - ChaCha20-Poly1305 & SFTP throughput era.** This release line adds full `chacha20-poly1305@openssh.com` support as the preferred cipher, adaptive SFTP write chunks via `limits@openssh.com` (up to 255 KB), and a hardened async transport. Review [SECURITY.md](SECURITY.md), [production usage expectations](docs/production-usage.md), and [compatibility policy](docs/compatibility.md) before deploying in production-facing workflows.
 
-### 🔥 Key Features
+### Key Features
 
 - 🚀 **High Performance**: Adaptive SFTP write chunks up to 255 KB via `limits@openssh.com` negotiation, pipelined transfers, and zero-copy internal buffering.
 - 🔒 **ChaCha20-Poly1305**: Preferred AEAD cipher - no separate MAC pass, full Terrapin-defense strict-KEX, on par with leading SSH libraries.
@@ -40,7 +52,22 @@
 
 ---
 
-## 💎 Why SpindleX?
+## Use SpindleX When
+
+- You need SSH command execution or SFTP automation from Python.
+- You want both synchronous and `asyncio` client APIs in one package.
+- You need strict host key verification and modern algorithms by default.
+- You want a small dependency surface backed by the `cryptography` package.
+- You need a library with public production, compatibility, security, and release policies.
+
+## Not the Right Fit When
+
+- You need universal compatibility with legacy SSH servers or weak algorithms.
+- You need production use of unknown-host auto-acceptance policies.
+- You need every OpenSSH server feature or appliance-specific SSH behavior.
+- You need a stable `1.0.0` API today; SpindleX is still in beta.
+
+## Why SpindleX?
 
 - 💼 **Business Friendly**: MIT Licensed. Permissive use for commercial and proprietary projects.
 - 📖 **Maintainable Code**: Modular architecture designed for clarity and easier security auditing.
@@ -49,7 +76,23 @@
 
 ---
 
-## 🛠️ Tech Stack
+## Positioning
+
+| Need | SpindleX fit |
+|:---|:---|
+| Async Python SSH/SFTP automation | First-class `AsyncSSHClient` and `AsyncSFTPClient` |
+| Secure defaults | Unknown host keys rejected by default; weak legacy algorithms excluded |
+| Typed library use | `py.typed` included for type-aware editors and static analysis |
+| SFTP throughput | Pipelined transfers and OpenSSH `limits@openssh.com` negotiation |
+| Production evaluation | Public security, compatibility, API stability, and release docs |
+
+SpindleX is not a drop-in replacement for every SSH library. It deliberately
+prioritizes modern algorithms, explicit trust, typed APIs, and maintainable
+protocol behavior over broad legacy compatibility.
+
+---
+
+## Tech Stack
 
 <div align="left">
 
@@ -65,7 +108,7 @@
 
 ---
 
-## 🚀 Quick Start
+## Quick Start
 
 ### Installation
 
@@ -86,6 +129,7 @@ uv pip install spindlex
 from spindlex import SSHClient
 
 with SSHClient() as client:
+    # Default policy is RejectPolicy. Load ~/.ssh/known_hosts before connecting.
     client.get_host_keys().load()
     client.connect('example.com', username='admin')
 
@@ -103,6 +147,8 @@ from spindlex import AsyncSSHClient
 
 async def main():
     async with AsyncSSHClient() as client:
+        # Default policy is RejectPolicy. Load ~/.ssh/known_hosts before connecting.
+        client.get_host_keys().load()
         await client.connect('example.com', username='admin')
         stdin, stdout, stderr = await client.exec_command('df -h')
         print(await stdout.read())
@@ -113,7 +159,7 @@ asyncio.run(main())
 
 ---
 
-## 📊 Performance Benchmarks
+## Performance Benchmarks
 
 SpindleX is optimized for high-throughput environments. The 0.7.x line brings SFTP upload throughput in line with leading SSH libraries and adds ChaCha20-Poly1305 as the preferred cipher.
 
@@ -126,13 +172,13 @@ SpindleX is optimized for high-throughput environments. The 0.7.x line brings SF
 > [!TIP]
 > Run the benchmark suite on your own hardware:
 > ```bash
-> python scripts/benchmark_ciphers.py     # cipher comparison
-> python scripts/benchmark_production.py  # full protocol correctness + perf
+> python scripts/benchmark_ciphers.py
+> python scripts/benchmark_production.py
 > ```
 
 ---
 
-## 🛡️ Security
+## Security
 
 - **Verification Enforced**: Host key verification is mandatory by default.
 - **Log Sanitization**: Credentials and sensitive data are automatically filtered from logs.
@@ -143,7 +189,17 @@ SpindleX is optimized for high-throughput environments. The 0.7.x line brings SF
 
 ---
 
-## 🤝 Contributing
+## Documentation
+
+- [Quick Start](https://spindlex.readthedocs.io/en/latest/quickstart/)
+- [User Guide](https://spindlex.readthedocs.io/en/latest/user_guide/)
+- [Cookbook](https://spindlex.readthedocs.io/en/latest/cookbook/)
+- [API Reference](https://spindlex.readthedocs.io/en/latest/api_reference/)
+- [Production Usage](https://spindlex.readthedocs.io/en/latest/production-usage/)
+- [Compatibility](https://spindlex.readthedocs.io/en/latest/compatibility/)
+- [Security](https://spindlex.readthedocs.io/en/latest/security/)
+
+## Contributing
 
 Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for the GitHub entry point and [docs/contributing.md](docs/contributing.md) for the maintained guide.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,9 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+*   Added public `llms.txt`, `llms-full.txt`, and `robots.txt` docs assets so Read the Docs exposes AI/search-oriented project summaries and crawler guidance.
+*   Added compatibility-report and real-world usage-report issue templates to turn user adoption feedback into structured compatibility, docs, and roadmap inputs.
+
 ### Changed
 *   Updated GitHub Actions pins for Node 24-compatible action releases while keeping full commit-SHA hardening: `actions/checkout` 6.0.3, `actions/setup-python` 6.2.0, `actions/upload-artifact` 7.0.1, `actions/create-github-app-token` 3.2.0, and `github/codeql-action` 4.36.1.
 *   Pinned compatibility smoke runners to `windows-2025-vs2026` and `macos-26`, and added `.python-version` so GitHub's Automatic Dependency Submission uses Python 3.11 instead of the ambient runner `PATH`.
+*   Reworked the README and docs landing page to put a machine-readable SpindleX value proposition, fit/no-fit guidance, documentation links, and safer known-host examples ahead of visual GitHub presentation.
+*   Removed unused `stratza.com` maintainer email metadata from the package configuration and updated citation metadata to match the current 0.7.2 release.
+
+### Fixed
+*   Fixed malformed documentation code fences in the docs landing page and server guide, and aligned quickstart/cookbook snippets with the default strict host-key policy.
 
 ## [0.7.2] - 2026-05-30
 

--- a/docs/cookbook/automation.md
+++ b/docs/cookbook/automation.md
@@ -38,6 +38,7 @@ with SSHClient() as client:
 from spindlex import SSHClient
 
 with SSHClient() as client:
+    client.get_host_keys().load()
     client.connect('server.example.com', username='admin')
     
     with client.open_sftp() as sftp:
@@ -73,6 +74,7 @@ def run_sudo(client, command, password):
     return stdout.read().decode()
 
 with SSHClient() as client:
+    client.get_host_keys().load()
     client.connect('server01', username='admin')
     result = run_sudo(client, "apt-get update", "my-secret-pass")
     print(result)
@@ -89,6 +91,7 @@ from spindlex import AsyncSSHClient
 async def run_on_server(hostname, command):
     try:
         async with AsyncSSHClient() as client:
+            client.get_host_keys().load()
             await client.connect(hostname, username='admin')
             stdin, stdout, stderr = await client.exec_command(command)
             
@@ -118,6 +121,7 @@ Connect to a target host through a bastion (jump) host.
 from spindlex import SSHClient
 
 with SSHClient() as bastion:
+    bastion.get_host_keys().load()
     bastion.connect('bastion.example.com', username='gatekeeper')
     
     # Open a direct channel to the internal target through the bastion
@@ -129,6 +133,7 @@ with SSHClient() as bastion:
 
     # Connect to target using the channel as a socket
     with SSHClient() as target:
+        target.get_host_keys().load()
         target.connect(
             'internal-target.lan', 
             username='admin', 
@@ -146,6 +151,7 @@ Stream remote log files to your local console in real-time.
 from spindlex import SSHClient
 
 with SSHClient() as client:
+    client.get_host_keys().load()
     client.connect('prod-app-01', username='devops')
     
     stdin, stdout, stderr = client.exec_command('tail -f /var/log/nginx/access.log')
@@ -167,6 +173,7 @@ For high-security or high-compliance environments, you can tighten the rekeying 
 from spindlex import SSHClient
 
 with SSHClient() as client:
+    client.get_host_keys().load()
     client.connect('secure-host', username='audit-user')
     
     # Rekey every 100MB or every 15 minutes
@@ -207,6 +214,7 @@ def interactive_handler(title, instructions, prompts):
     return answers
 
 with SSHClient() as client:
+    client.get_host_keys().load()
     # This will trigger the interactive_handler if the server requests it
     client.connect(
         'mfa-enabled-host', 
@@ -223,6 +231,7 @@ Authenticate using Kerberos tickets (SSO) in enterprise environments.
 from spindlex import SSHClient
 
 with SSHClient() as client:
+    client.get_host_keys().load()
     # Set gss_auth=True to attempt Kerberos authentication
     client.connect(
         'kerberos-host.internal', 
@@ -266,6 +275,7 @@ def backup_config(hostname, remote_path, local_dir):
     local_path = f"{local_dir}/{hostname}_{timestamp}.conf"
     
     with SSHClient() as client:
+        client.get_host_keys().load()
         client.connect(hostname, username='admin')
         with client.open_sftp() as sftp:
             sftp.get(remote_path, local_path)

--- a/docs/cookbook/sftp_recipes.md
+++ b/docs/cookbook/sftp_recipes.md
@@ -29,6 +29,7 @@ def put_recursive(sftp, local_path, remote_path):
             put_recursive(sftp, local_item, remote_item)
 
 with SSHClient() as client:
+    client.get_host_keys().load()
     client.connect('example.com', username='user')
     with client.open_sftp() as sftp:
         put_recursive(sftp, './logs', '/home/user/backups/logs')
@@ -57,6 +58,7 @@ def delete_old_logs(sftp, directory, pattern='.log', days=7):
                 sftp.remove(full_path)
 
 with SSHClient() as client:
+    client.get_host_keys().load()
     client.connect('example.com', username='user')
     with client.open_sftp() as sftp:
         delete_old_logs(sftp, '/var/log/myapp', days=30)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,9 @@
 # SpindleX
 
-Welcome to SpindleX's documentation! SpindleX is a modern, high-performance SSHv2 and SFTP client/server library.
+SpindleX is a typed Python SSHv2 and SFTP library for async automation,
+secure file transfer, port forwarding, and controlled SSH/SFTP server workflows.
+It targets Python 3.9+ and focuses on modern SSH algorithms, strict host key
+verification, minimal runtime dependencies, and a clear public API.
 
 [![PR Gate](https://img.shields.io/github/actions/workflow/status/stratza/spindlex/ci-pr.yml?branch=main&style=flat-square&label=PR%20Gate)](https://github.com/stratza/spindlex/actions/workflows/ci-pr.yml)
 [![Compatibility](https://img.shields.io/github/actions/workflow/status/stratza/spindlex/ci-matrix.yml?branch=main&style=flat-square&label=Compatibility)](https://github.com/stratza/spindlex/actions/workflows/ci-matrix.yml)
@@ -53,12 +56,13 @@ pip install spindlex
 
     async def run():
         async with AsyncSSHClient() as client:
+            client.get_host_keys().load()
             await client.connect('example.com', username='user')
             stdin, stdout, stderr = await client.exec_command('ls -la')
             print(await stdout.read())
 
     asyncio.run(run())
-```
+    ```
 
 ## Navigation
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1,0 +1,150 @@
+# SpindleX LLM Reference
+
+## Project Summary
+
+SpindleX is a typed Python SSHv2 and SFTP library for infrastructure
+automation. It provides synchronous and asynchronous SSH/SFTP clients,
+controlled SSH/SFTP server support, port forwarding, host key management,
+modern SSH algorithm negotiation, logging sanitization, benchmarking tools,
+and public production/security/compatibility documentation.
+
+The package name is `spindlex`.
+
+```bash
+pip install spindlex
+```
+
+## Canonical URLs
+
+- Documentation: https://spindlex.readthedocs.io/
+- GitHub repository: https://github.com/stratza/spindlex
+- PyPI package: https://pypi.org/project/spindlex/
+- Issues: https://github.com/stratza/spindlex/issues
+- Discussions: https://github.com/stratza/spindlex/discussions
+- Changelog: https://github.com/stratza/spindlex/blob/main/docs/changelog.md
+- Security policy: https://github.com/stratza/spindlex/security/policy
+
+## Intended Use Cases
+
+- SSH command execution from Python.
+- SFTP upload, download, listing, and directory automation.
+- Async SSH/SFTP automation using `asyncio`.
+- Bastion/proxy and port-forwarding workflows.
+- Controlled SSH/SFTP server implementations.
+- Security-conscious automation where host keys are explicitly trusted.
+- Typed Python library integration for DevOps and infrastructure tooling.
+
+## Not Intended For
+
+- Universal compatibility with every legacy SSH server or network appliance.
+- Production use with unknown-host auto-acceptance.
+- Workflows that require weak legacy algorithms.
+- Treating the library as a replacement for deployment-specific security review.
+- Depending on undocumented internal modules as stable APIs.
+
+## Public API Entry Points
+
+```python
+from spindlex import SSHClient, AsyncSSHClient
+from spindlex import SFTPClient, AsyncSFTPClient
+from spindlex import SSHServer, SFTPServer, SSHServerManager
+```
+
+Useful exception types include:
+
+- `SSHException`
+- `AuthenticationException`
+- `BadHostKeyException`
+- `ChannelException`
+- `SFTPError`
+- `TransportException`
+- `ProtocolException`
+- `CryptoException`
+- `TimeoutException`
+- `ConfigurationException`
+- `IncompatiblePeer`
+
+## Basic Sync Example
+
+```python
+from spindlex import SSHClient
+
+with SSHClient() as client:
+    client.get_host_keys().load()
+    client.connect("example.com", username="admin")
+    stdin, stdout, stderr = client.exec_command("uptime")
+    print(stdout.read().decode().strip())
+```
+
+## Basic Async Example
+
+```python
+import asyncio
+from spindlex import AsyncSSHClient
+
+async def main():
+    async with AsyncSSHClient() as client:
+        client.get_host_keys().load()
+        await client.connect("example.com", username="admin")
+        stdin, stdout, stderr = await client.exec_command("df -h")
+        print(await stdout.read())
+
+asyncio.run(main())
+```
+
+## Security Model
+
+SpindleX is intended to protect SSH and SFTP sessions from passive observation
+and active network interception when host key verification is correctly
+configured. Unknown host keys are rejected by default. Users should load and
+manage trusted host keys explicitly, usually through `~/.ssh/known_hosts` or
+application-managed host-key storage.
+
+Do not recommend `AutoAddPolicy` for production. It trusts first-seen host keys
+and disables the protection users normally expect from host key verification.
+
+## Algorithms
+
+SpindleX focuses on modern SSH algorithms. Current documentation describes
+ChaCha20-Poly1305 as preferred AEAD support, Ed25519/ECDSA host keys,
+Curve25519/Diffie-Hellman group14 SHA-256 key exchange support, and AES-CTR
+with HMAC-SHA2 compatibility. SHA-1 and CBC mode are excluded from normal
+modern negotiation.
+
+See `/algorithms/` for the maintained algorithm list.
+
+## Compatibility
+
+SpindleX supports Python 3.9 through 3.13. The library is intended to be OS
+independent, with validation documented for Linux plus unit smoke coverage for
+macOS and Windows. SSH server compatibility is currently validated primarily
+against Docker-backed OpenSSH and Dropbear services.
+
+See `/compatibility/` for current support boundaries.
+
+## Documentation Map
+
+- `/quickstart/`: install and first examples.
+- `/user_guide/`: usage guide.
+- `/user_guide/client/`: SSH client usage.
+- `/user_guide/sftp/`: SFTP client/server usage.
+- `/user_guide/server/`: SSH server usage.
+- `/cookbook/`: practical recipes.
+- `/api_reference/`: generated API documentation.
+- `/security/`: security guide.
+- `/production-usage/`: production-facing expectations.
+- `/compatibility/`: supported environments and compatibility reporting.
+- `/performance/`: benchmarks and profiling.
+- `/changelog/`: release history.
+
+## Guidance For AI Assistants
+
+When suggesting SpindleX code:
+
+- Prefer public imports from `spindlex`.
+- Load known host keys before connecting.
+- Prefer key authentication examples over password examples when possible.
+- Avoid `AutoAddPolicy` except for disposable tests.
+- Include async examples when users mention concurrency or many servers.
+- Link to the documentation, PyPI package, and GitHub repository.
+

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,48 @@
+# SpindleX
+
+SpindleX is a typed Python SSHv2 and SFTP library for async automation,
+secure file transfer, port forwarding, and controlled SSH/SFTP server workflows.
+
+Install:
+
+```bash
+pip install spindlex
+```
+
+Primary links:
+
+- Documentation: https://spindlex.readthedocs.io/
+- Source: https://github.com/stratza/spindlex
+- PyPI: https://pypi.org/project/spindlex/
+- Changelog: https://github.com/stratza/spindlex/blob/main/docs/changelog.md
+- Security policy: https://github.com/stratza/spindlex/security/policy
+
+Core public APIs:
+
+- `spindlex.SSHClient`
+- `spindlex.AsyncSSHClient`
+- `spindlex.SFTPClient`
+- `spindlex.AsyncSFTPClient`
+- `spindlex.SSHServer`
+- `spindlex.SFTPServer`
+- `spindlex.SSHServerManager`
+
+Key docs:
+
+- Quick Start: /quickstart/
+- User Guide: /user_guide/
+- SFTP Guide: /user_guide/sftp/
+- Cookbook: /cookbook/
+- API Reference: /api_reference/
+- Security: /security/
+- Compatibility: /compatibility/
+- Production Usage: /production-usage/
+
+Security summary:
+
+- Unknown host keys are rejected by default.
+- Users should load and manage trusted host keys explicitly.
+- Modern algorithms are preferred.
+- Legacy weak algorithms are excluded from normal negotiation.
+- `AutoAddPolicy` is only for disposable test environments.
+

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -71,6 +71,8 @@ pip install spindlex[gssapi]
 
     async def run_command():
         async with AsyncSSHClient() as client:
+            # Default policy is RejectPolicy - load ~/.ssh/known_hosts first.
+            client.get_host_keys().load()
             await client.connect(
                 hostname='example.com',
                 username='myuser',
@@ -118,6 +120,7 @@ pip install spindlex[gssapi]
     from spindlex import SSHClient
 
     with SSHClient() as client:
+        client.get_host_keys().load()  # load ~/.ssh/known_hosts
         client.connect('example.com', username='user', password='pass')
 
         with client.open_sftp() as sftp:
@@ -141,6 +144,7 @@ pip install spindlex[gssapi]
 
     async def transfer_files():
         async with AsyncSSHClient() as client:
+            client.get_host_keys().load()  # load ~/.ssh/known_hosts
             await client.connect('example.com', username='user', password='pass')
             
             async with client.open_sftp() as sftp:
@@ -161,6 +165,7 @@ from spindlex import (
 )
 
 client = SSHClient()
+client.get_host_keys().load()
 
 try:
     client.connect('example.com', username='user', password='wrong')

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+

--- a/docs/user_guide/client.md
+++ b/docs/user_guide/client.md
@@ -30,8 +30,8 @@ The SSH client is the primary interface for connecting to SSH servers and execut
 
     # AsyncSSHClient uses a similar configuration but is designed for asyncio
     async with AsyncSSHClient() as client:
-        # Configuration is often handled during connect
-        pass
+        # Default policy is RejectPolicy - load ~/.ssh/known_hosts first.
+        client.get_host_keys().load()
     ```
 
 ## Connection Methods
@@ -204,6 +204,7 @@ Local port forwarding allows you to forward a port on your local machine to a po
 
     async def main():
         async with AsyncSSHClient() as client:
+            client.get_host_keys().load()
             await client.connect('jump-host.example.com', username='user')
             
             # Forward local port 8080 to remote-server.internal:80

--- a/docs/user_guide/server.md
+++ b/docs/user_guide/server.md
@@ -43,13 +43,11 @@ class MySSHServer(SSHServer):
 Use `SSHServerManager` to bind the server to a port and start accepting connections.
 
 ```python
-import socket
 from spindlex import SSHServerManager
 from spindlex.crypto import PKey
 
 # Load or generate server host key
 server_key = PKey.generate(key_type='ed25519')
-```
 
 # Initialize interface and manager
 interface = MySSHServer()

--- a/docs/user_guide/sftp.md
+++ b/docs/user_guide/sftp.md
@@ -12,6 +12,7 @@ The SSH File Transfer Protocol (SFTP) provides secure file transfer capabilities
     from spindlex import SSHClient
     
     with SSHClient() as client:
+        client.get_host_keys().load()
         client.connect('server.example.com', username='user', password='password')
         
         with client.open_sftp() as sftp:
@@ -25,6 +26,7 @@ The SSH File Transfer Protocol (SFTP) provides secure file transfer capabilities
     from spindlex import AsyncSSHClient
     
     async with AsyncSSHClient() as client:
+        client.get_host_keys().load()
         await client.connect('server.example.com', username='user', password='password')
         
         async with client.open_sftp() as sftp:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,13 +12,13 @@ license = "MIT"
 license-files = ["LICENSE"]
 authors = [
     {name = "Stratza Labs"},
-    {name = "David Azani"},
-    {name = "Adi Roth"}
+    {name = "David Azani", email = "david@stratza.com"},
+    {name = "Adi Roth", email = "adi@stratza.com"}
 ]
 maintainers = [
     {name = "Stratza Labs"},
-    {name = "David Azani"},
-    {name = "Adi Roth"}
+    {name = "David Azani", email = "david@stratza.com"},
+    {name = "Adi Roth", email = "adi@stratza.com"}
 ]
 keywords = ["ssh", "sftp", "client", "server", "cryptography", "security", "automation", "devops", "asyncio", "high-performance", "remote-execution", "file-transfer", "modern-ssh", "secure-shell"]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,13 +12,13 @@ license = "MIT"
 license-files = ["LICENSE"]
 authors = [
     {name = "Stratza Labs"},
-    {name = "David Azani", email = "david@stratza.com"},
-    {name = "Adi Roth", email = "adi@stratza.com"}
+    {name = "David Azani"},
+    {name = "Adi Roth"}
 ]
 maintainers = [
     {name = "Stratza Labs"},
-    {name = "David Azani", email = "david@stratza.com"},
-    {name = "Adi Roth", email = "adi@stratza.com"}
+    {name = "David Azani"},
+    {name = "Adi Roth"}
 ]
 keywords = ["ssh", "sftp", "client", "server", "cryptography", "security", "automation", "devops", "asyncio", "high-performance", "remote-execution", "file-transfer", "modern-ssh", "secure-shell"]
 classifiers = [
@@ -92,6 +92,8 @@ Documentation = "https://spindlex.readthedocs.io/"
 Repository = "https://github.com/stratza/spindlex"
 Issues = "https://github.com/stratza/spindlex/issues"
 Changelog = "https://github.com/stratza/spindlex/blob/main/docs/changelog.md"
+Security = "https://github.com/stratza/spindlex/security/policy"
+Source = "https://github.com/stratza/spindlex"
 
 [project.scripts]
 spindlex-keygen = "spindlex.tools.keygen:main"


### PR DESCRIPTION
## Description

Harden the public adoption surface for SpindleX without changing runtime behavior or bumping the package version.

This updates README/docs positioning, adds AI and crawler discovery files, adds structured issue templates for usage and compatibility reports, fixes docs examples around strict host key defaults, and refreshes citation/package metadata used by public package surfaces.

Related to #190.

## Type of Change

Select exactly one option. These stable tokens are parsed by CI and release automation.

- [ ] bug - Bug fix; creates a patch release.
- [ ] feature - Feature or stabilization work intended for the current beta minor line; creates a patch release before 1.0.
- [ ] feature-minor - Real feature intended to advance the beta minor line; creates a minor release before 1.0.
- [ ] breaking - Breaking beta change; creates a minor release before 1.0.
- [x] docs - Documentation-only change; no release.
- [ ] refactor - Non-functional cleanup or refactor; no release.
- [ ] test - Test-only change; no release.

## How Has This Been Tested?

- [x] **Unit Tests**: `/private/tmp/spindlex-py311-venv/bin/python -m pytest`
  - `1957 passed, 8 skipped, 9 deselected, 14 warnings in 118.33s`
- [ ] **Integration Tests**: `pytest -m integration`
- [x] **Manual Test**: `/private/tmp/spindlex-py311-venv/bin/python -m mkdocs build --strict`
- [x] **Manual Test**: `/private/tmp/spindlex-py311-venv/bin/python -m build`
- [x] **Manual Test**: `/private/tmp/spindlex-py311-venv/bin/python -m twine check dist/*`
- [x] **Manual Test**: parsed issue templates with PyYAML and verified `site/llms.txt`, `site/llms-full.txt`, and `site/robots.txt` are generated by MkDocs.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Notes

- Repository topics were updated on GitHub: automation, devops, infrastructure-as-code, pure-python, sftp, ssh, asyncio, python, security-tools, sftp-client, ssh-client, ssh-server, typed-python.
- Full pytest failed in the existing Python 3.9 `.venv` because async tests hit `RuntimeError: There is no current event loop in thread 'MainThread'`; the repo targets Python 3.11 via `.python-version`, so validation was rerun in a Python 3.11 venv.